### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,5 +1,9 @@
 name: .NET
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/baoduy/DKNet/security/code-scanning/1](https://github.com/baoduy/DKNet/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will explicitly define the minimal permissions required for the workflow to function. Based on the context, the workflow likely needs `contents: read` to access the repository's contents and possibly `packages: write` to publish to NuGet. We will set these permissions explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
