### PR TITLE
Potential fix for code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/z_Templates/SlimBus.ApiEndpoints/SlimBus.Api/Configs/Idempotency/IIdempotencyKeyRepository.cs
+++ b/z_Templates/SlimBus.ApiEndpoints/SlimBus.Api/Configs/Idempotency/IIdempotencyKeyRepository.cs
@@ -29,6 +29,7 @@ internal class IdempotencyKeyRepository(IDistributedCache cache, IOptions<Idempo
 
     public async ValueTask<(bool processed, string? result)> IsKeyProcessedAsync(string idempotencyKey)
     {
+        idempotencyKey = idempotencyKey.Replace("\n", "").Replace("\r", ""); // Sanitize user input
         var cacheKey = $"{_options.CachePrefix}{idempotencyKey}";
         logger.LogDebug("Trying to get existing result for cache key: {CacheKey}", cacheKey);
 
@@ -40,6 +41,7 @@ internal class IdempotencyKeyRepository(IDistributedCache cache, IOptions<Idempo
 
     public async ValueTask MarkKeyAsProcessedAsync(string idempotencyKey, string? result)
     {
+        idempotencyKey = idempotencyKey.Replace("\n", "").Replace("\r", ""); // Sanitize user input
         var cacheKey = $"{_options.CachePrefix}{idempotencyKey}";
         logger.LogDebug("Setting cache result for cache key: {CacheKey}", cacheKey);
 

--- a/z_Templates/SlimBus.ApiEndpoints/SlimBus.Api/Configs/Idempotency/IdempotencyEndpointFilter.cs
+++ b/z_Templates/SlimBus.ApiEndpoints/SlimBus.Api/Configs/Idempotency/IdempotencyEndpointFilter.cs
@@ -18,6 +18,7 @@ internal sealed class IdempotencyEndpointFilter(IIdempotencyKeyRepository cacher
     public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
     {
         var idempotencyKey = context.HttpContext.Request.Headers[_options.IdempotencyHeaderKey].FirstOrDefault();
+        idempotencyKey = idempotencyKey?.Replace("\n", "").Replace("\r", ""); // Sanitize user input
         logger.LogDebug("Checking idempotency header key: {Key}", _options.IdempotencyHeaderKey);
 
         var endpoint = context.HttpContext.GetEndpoint();

--- a/z_Templates/SlimBus.ApiEndpoints/SlimBus.Api/Configs/Idempotency/IdempotencyEndpointFilter.cs
+++ b/z_Templates/SlimBus.ApiEndpoints/SlimBus.Api/Configs/Idempotency/IdempotencyEndpointFilter.cs
@@ -18,7 +18,7 @@ internal sealed class IdempotencyEndpointFilter(IIdempotencyKeyRepository cacher
     public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
     {
         var idempotencyKey = context.HttpContext.Request.Headers[_options.IdempotencyHeaderKey].FirstOrDefault();
-        idempotencyKey = idempotencyKey?.Replace("\n", "").Replace("\r", ""); // Sanitize user input
+        idempotencyKey = SanitizeForLogging(idempotencyKey); // Sanitize user input
         logger.LogDebug("Checking idempotency header key: {Key}", _options.IdempotencyHeaderKey);
 
         var endpoint = context.HttpContext.GetEndpoint();

--- a/z_Templates/SlimBus.ApiEndpoints/SlimBus.Share/Extensions/SanitizeForLogging.cs
+++ b/z_Templates/SlimBus.ApiEndpoints/SlimBus.Share/Extensions/SanitizeForLogging.cs
@@ -1,0 +1,12 @@
+namespace SlimBus.Share.Extensions;
+
+public static class SanitizeForLoggingExtensions
+{
+    public static string SanitizeForLogging(this string value) =>
+        value.Replace("\n", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Replace("\t", string.Empty, StringComparison.OrdinalIgnoreCase)
+            .Trim() // Trim leading and trailing spaces
+            .Replace('\0', ' ') // Replace null characters
+            .Replace('\f', ' ') // Replace form feed characters
+            .Replace('\r', ' '); // Sanitize user input
+}

--- a/z_Templates/SlimBus.ApiEndpoints/SlimBus.Share/SlimBus.Share.csproj
+++ b/z_Templates/SlimBus.ApiEndpoints/SlimBus.Share/SlimBus.Share.csproj
@@ -22,7 +22,4 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Potential fix for [https://github.com/baoduy/DKNet/security/code-scanning/2](https://github.com/baoduy/DKNet/security/code-scanning/2)

To fix the issue, sanitize the `idempotencyKey` before using it to construct the `cacheKey` and logging it. Specifically:
1. Remove newline characters (`\n`, `\r`) from the `idempotencyKey` to prevent log forging in plain text logs.
2. Optionally, encode the `idempotencyKey` using a method like `HttpUtility.HtmlEncode` if logs are displayed in HTML format.

The sanitization should be applied in both `IdempotencyEndpointFilter.cs` (where `idempotencyKey` is first derived) and `IIdempotencyKeyRepository.cs` (where `cacheKey` is logged). This ensures that all instances of logging involving user input are secure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
