### PR TITLE
enhance to support the value type comparison

### DIFF
--- a/src/DKNet.FW.sln.DotSettings.user
+++ b/src/DKNet.FW.sln.DotSettings.user
@@ -559,10 +559,8 @@
 &lt;/AssemblyExplorer&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=_002ATests_002A_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=0f252555_002D8b6d_002D4866_002D999e_002D0e7ba9eec91d/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;EfCore&amp;gt;\&amp;lt;EfCore.Specifications.Tests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
-  &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/EfCore.Specifications.Tests" Presentation="&amp;lt;EfCore&amp;gt;\&amp;lt;EfCore.Specifications.Tests&amp;gt;" /&gt;
-&lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=a0a74494_002Da615_002D49dd_002D8d12_002Df8ff243d2139/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+	
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=a0a74494_002Da615_002D49dd_002D8d12_002Df8ff243d2139/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Or&gt;
     &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src" Presentation="&amp;lt;AspNet&amp;gt;" /&gt;
     &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src" Presentation="&amp;lt;Core&amp;gt;" /&gt;

--- a/src/EfCore/DKNet.EfCore.Specifications/DynamicPredicateExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/DynamicPredicateExtensions.cs
@@ -21,9 +21,9 @@ public static class DynamicPredicateExtensions
     /// <typeparam name="T">Entity type for which the predicate is being constructed.</typeparam>
     /// <param name="builder">Callback that configures the dynamic predicate (expression text and parameter values).</param>
     /// <returns>A compiled <see cref="Expression{TDelegate}" /> representing the dynamic predicate.</returns>
-    private static Expression<Func<T, bool>> CreateDynamicExpression<T>(Action<DynamicPredicateBuilder> builder)
+    private static Expression<Func<T, bool>> CreateDynamicExpression<T>(Action<DynamicPredicateBuilder<T>> builder)
     {
-        var dynamic = new DynamicPredicateBuilder();
+        var dynamic = new DynamicPredicateBuilder<T>();
         builder(dynamic);
 
         var (expression, values) = dynamic.Build();
@@ -47,9 +47,9 @@ public static class DynamicPredicateExtensions
     ///     The extended <see cref="ExpressionStarter{T}" /> with the AND condition applied
     /// </returns>
     public static Expression<Func<T, bool>> DynamicAnd<T>(this Expression<Func<T, bool>> predicate,
-        Action<DynamicPredicateBuilder> builder) =>
+        Action<DynamicPredicateBuilder<T>> builder) =>
         // Explicit type argument required to satisfy generic inference (previously caused CS0411)
-        predicate.And(CreateDynamicExpression<T>(builder));
+        predicate.And(CreateDynamicExpression(builder));
 
     /// <summary>
     ///     Combines the existing predicate with a new dynamic condition using AND logic.
@@ -63,8 +63,8 @@ public static class DynamicPredicateExtensions
     ///     The extended <see cref="ExpressionStarter{T}" /> with the AND condition applied
     /// </returns>
     public static Expression<Func<T, bool>> DynamicAnd<T>(this ExpressionStarter<T> predicate,
-        Action<DynamicPredicateBuilder> builder) =>
-        predicate.And(CreateDynamicExpression<T>(builder));
+        Action<DynamicPredicateBuilder<T>> builder) =>
+        predicate.And(CreateDynamicExpression(builder));
 
     /// <summary>
     ///     Combines the existing predicate with a new dynamic condition using OR logic.
@@ -79,8 +79,8 @@ public static class DynamicPredicateExtensions
     /// </returns>
     public static Expression<Func<T, bool>> DynamicOr<T>(
         this Expression<Func<T, bool>> predicate,
-        Action<DynamicPredicateBuilder> builder) =>
-        predicate.Or(CreateDynamicExpression<T>(builder));
+        Action<DynamicPredicateBuilder<T>> builder) =>
+        predicate.Or(CreateDynamicExpression(builder));
 
     /// <summary>
     ///     Combines the existing predicate with a new dynamic condition using OR logic.
@@ -95,8 +95,8 @@ public static class DynamicPredicateExtensions
     /// </returns>
     public static Expression<Func<T, bool>> DynamicOr<T>(
         this ExpressionStarter<T> predicate,
-        Action<DynamicPredicateBuilder> builder) =>
-        predicate.Or(CreateDynamicExpression<T>(builder));
+        Action<DynamicPredicateBuilder<T>> builder) =>
+        predicate.Or(CreateDynamicExpression(builder));
 
     #endregion
 }

--- a/src/EfCore/EfCore.DtoGenerator.Tests/DtoMappingTests.cs
+++ b/src/EfCore/EfCore.DtoGenerator.Tests/DtoMappingTests.cs
@@ -56,32 +56,32 @@ public class DtoMappingTests
 
         // Assert
         countryProperty.ShouldNotBeNull();
-        var countryMaxLength = countryProperty!.GetCustomAttributes(typeof(MaxLengthAttribute), false)
+        var countryMaxLength = countryProperty.GetCustomAttributes(typeof(MaxLengthAttribute), false)
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         countryMaxLength.ShouldNotBeNull();
-        countryMaxLength!.Length.ShouldBe(3);
+        countryMaxLength.Length.ShouldBe(3);
 
         currencyProperty.ShouldNotBeNull();
-        var currencyMaxLength = currencyProperty!.GetCustomAttributes(typeof(MaxLengthAttribute), false)
+        var currencyMaxLength = currencyProperty.GetCustomAttributes(typeof(MaxLengthAttribute), false)
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         currencyMaxLength.ShouldNotBeNull();
-        currencyMaxLength!.Length.ShouldBe(4);
+        currencyMaxLength.Length.ShouldBe(4);
 
         nameProperty.ShouldNotBeNull();
-        var nameMaxLength = nameProperty!.GetCustomAttributes(typeof(MaxLengthAttribute), false)
+        var nameMaxLength = nameProperty.GetCustomAttributes(typeof(MaxLengthAttribute), false)
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         nameMaxLength.ShouldNotBeNull();
-        nameMaxLength!.Length.ShouldBe(50);
+        nameMaxLength.Length.ShouldBe(50);
 
         codeProperty.ShouldNotBeNull();
-        var codeMaxLength = codeProperty!.GetCustomAttributes(typeof(MaxLengthAttribute), false)
+        var codeMaxLength = codeProperty.GetCustomAttributes(typeof(MaxLengthAttribute), false)
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         codeMaxLength.ShouldNotBeNull();
-        codeMaxLength!.Length.ShouldBe(10);
+        codeMaxLength.Length.ShouldBe(10);
     }
 
     [Fact]
@@ -151,25 +151,25 @@ public class DtoMappingTests
 
         // Assert
         codeProperty.ShouldNotBeNull();
-        var codeMaxLength = codeProperty!.GetCustomAttributes(typeof(MaxLengthAttribute), false)
+        var codeMaxLength = codeProperty.GetCustomAttributes(typeof(MaxLengthAttribute), false)
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         codeMaxLength.ShouldNotBeNull();
-        codeMaxLength!.Length.ShouldBe(10);
+        codeMaxLength.Length.ShouldBe(10);
 
         nameProperty.ShouldNotBeNull();
-        var nameMaxLength = nameProperty!.GetCustomAttributes(typeof(MaxLengthAttribute), false)
+        var nameMaxLength = nameProperty.GetCustomAttributes(typeof(MaxLengthAttribute), false)
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         nameMaxLength.ShouldNotBeNull();
-        nameMaxLength!.Length.ShouldBe(50);
+        nameMaxLength.Length.ShouldBe(50);
 
         descriptionProperty.ShouldNotBeNull();
-        var descriptionMaxLength = descriptionProperty!.GetCustomAttributes(typeof(MaxLengthAttribute), false)
+        var descriptionMaxLength = descriptionProperty.GetCustomAttributes(typeof(MaxLengthAttribute), false)
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         descriptionMaxLength.ShouldNotBeNull();
-        descriptionMaxLength!.Length.ShouldBe(200);
+        descriptionMaxLength.Length.ShouldBe(200);
     }
 
     [Fact]
@@ -418,18 +418,18 @@ public class DtoMappingTests
         // Test Required attributes
         var nameProperty = typeof(TestProductDto).GetProperty("Name");
         nameProperty.ShouldNotBeNull();
-        nameProperty!.GetCustomAttributes(typeof(RequiredAttribute), false).ShouldNotBeEmpty();
+        nameProperty.GetCustomAttributes(typeof(RequiredAttribute), false).ShouldNotBeEmpty();
 
         var skuProperty = typeof(TestProductDto).GetProperty("Sku");
         skuProperty.ShouldNotBeNull();
-        skuProperty!.GetCustomAttributes(typeof(RequiredAttribute), false).ShouldNotBeEmpty();
+        skuProperty.GetCustomAttributes(typeof(RequiredAttribute), false).ShouldNotBeEmpty();
 
         // Test StringLength attribute with MinimumLength
         var stringLengthAttr = nameProperty.GetCustomAttributes(typeof(StringLengthAttribute), false)
             .Cast<StringLengthAttribute>()
             .FirstOrDefault();
         stringLengthAttr.ShouldNotBeNull();
-        stringLengthAttr!.MaximumLength.ShouldBe(100);
+        stringLengthAttr.MaximumLength.ShouldBe(100);
         stringLengthAttr.MinimumLength.ShouldBe(3);
 
         // Test MaxLength attribute
@@ -437,42 +437,42 @@ public class DtoMappingTests
             .Cast<MaxLengthAttribute>()
             .FirstOrDefault();
         maxLengthAttr.ShouldNotBeNull();
-        maxLengthAttr!.Length.ShouldBe(50);
+        maxLengthAttr.Length.ShouldBe(50);
 
         // Test Range attributes
         var priceProperty = typeof(TestProductDto).GetProperty("Price");
         priceProperty.ShouldNotBeNull();
-        var priceRangeAttr = priceProperty!.GetCustomAttributes(typeof(RangeAttribute), false)
+        var priceRangeAttr = priceProperty.GetCustomAttributes(typeof(RangeAttribute), false)
             .Cast<RangeAttribute>()
             .FirstOrDefault();
         priceRangeAttr.ShouldNotBeNull();
-        priceRangeAttr!.Minimum.ShouldBe(0.01);
+        priceRangeAttr.Minimum.ShouldBe(0.01);
         priceRangeAttr.Maximum.ShouldBe(999999.99);
 
         var stockProperty = typeof(TestProductDto).GetProperty("StockQuantity");
         stockProperty.ShouldNotBeNull();
-        var stockRangeAttr = stockProperty!.GetCustomAttributes(typeof(RangeAttribute), false)
+        var stockRangeAttr = stockProperty.GetCustomAttributes(typeof(RangeAttribute), false)
             .Cast<RangeAttribute>()
             .FirstOrDefault();
         stockRangeAttr.ShouldNotBeNull();
-        stockRangeAttr!.Minimum.ShouldBe(0);
+        stockRangeAttr.Minimum.ShouldBe(0);
         stockRangeAttr.Maximum.ShouldBe(10000);
 
         // Test EmailAddress attribute
         var emailProperty = typeof(TestProductDto).GetProperty("Email");
         emailProperty.ShouldNotBeNull();
-        emailProperty!.GetCustomAttributes(typeof(EmailAddressAttribute), false).ShouldNotBeEmpty();
+        emailProperty.GetCustomAttributes(typeof(EmailAddressAttribute), false).ShouldNotBeEmpty();
 
         // Note: Uri? properties don't need [Url] attribute as Uri type itself validates URLs
         // The [Url] attribute is meant for string properties only
         var urlProperty = typeof(TestProductDto).GetProperty("WebsiteUrl");
         urlProperty.ShouldNotBeNull();
-        urlProperty!.PropertyType.ShouldBe(typeof(Uri));
+        urlProperty.PropertyType.ShouldBe(typeof(Uri));
 
         // Test Phone attribute
         var phoneProperty = typeof(TestProductDto).GetProperty("PhoneNumber");
         phoneProperty.ShouldNotBeNull();
-        phoneProperty!.GetCustomAttributes(typeof(PhoneAttribute), false).ShouldNotBeEmpty();
+        phoneProperty.GetCustomAttributes(typeof(PhoneAttribute), false).ShouldNotBeEmpty();
     }
 
     [Fact]

--- a/src/EfCore/EfCore.DtoGenerator.Tests/IgnoreComplexTypeTests.cs
+++ b/src/EfCore/EfCore.DtoGenerator.Tests/IgnoreComplexTypeTests.cs
@@ -22,19 +22,19 @@ public class IgnoreComplexTypeTests
         var ordersProperty = typeof(CustomerDto).GetProperty("Orders");
 
         customerIdProperty.ShouldNotBeNull();
-        customerIdProperty!.PropertyType.ShouldBe(typeof(int));
+        customerIdProperty.PropertyType.ShouldBe(typeof(int));
 
         nameProperty.ShouldNotBeNull();
-        nameProperty!.PropertyType.ShouldBe(typeof(string));
+        nameProperty.PropertyType.ShouldBe(typeof(string));
 
         emailProperty.ShouldNotBeNull();
-        emailProperty!.PropertyType.ShouldBe(typeof(string));
+        emailProperty.PropertyType.ShouldBe(typeof(string));
 
         primaryAddressProperty.ShouldNotBeNull();
-        primaryAddressProperty!.PropertyType.ShouldBe(typeof(Address));
+        primaryAddressProperty.PropertyType.ShouldBe(typeof(Address));
 
         ordersProperty.ShouldNotBeNull();
-        ordersProperty!.PropertyType.ShouldBe(typeof(ICollection<Order>));
+        ordersProperty.PropertyType.ShouldBe(typeof(ICollection<Order>));
     }
 
     [Fact]

--- a/src/EfCore/EfCore.Encryption.Tests/AesGcmColumnEncryptionProviderTests.cs
+++ b/src/EfCore/EfCore.Encryption.Tests/AesGcmColumnEncryptionProviderTests.cs
@@ -19,9 +19,9 @@ public class AesGcmColumnEncryptionProviderTests
     public AesGcmColumnEncryptionProviderTests()
     {
         // Initialize with random bytes for testing
-        RandomNumberGenerator.Fill(this._validKey16);
-        RandomNumberGenerator.Fill(this._validKey24);
-        RandomNumberGenerator.Fill(this._validKey32);
+        RandomNumberGenerator.Fill(_validKey16);
+        RandomNumberGenerator.Fill(_validKey24);
+        RandomNumberGenerator.Fill(_validKey32);
     }
 
     #endregion
@@ -77,7 +77,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Decrypt_WithCorruptedCiphertext_ShouldThrowInvalidOperationException()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
         const string plaintext = "Test message";
         var encrypted = provider.Encrypt(plaintext);
 
@@ -95,7 +95,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Decrypt_WithEmptyString_ShouldReturnEmptyString()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
 
         // Act
         var result = provider.Decrypt(string.Empty);
@@ -108,7 +108,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Decrypt_WithInvalidBase64_ShouldThrowException()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
         const string invalidBase64 = "Not a valid base64 string!";
 
         // Act & Assert
@@ -119,7 +119,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Decrypt_WithNull_ShouldReturnNull()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
 
         // Act
         var result = provider.Decrypt(null);
@@ -132,7 +132,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Decrypt_WithTooShortCiphertext_ShouldThrowArgumentException()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
         var shortData = new byte[10]; // Less than IV (12) + Tag (16) = 28 bytes
         var shortCiphertext = Convert.ToBase64String(shortData);
 
@@ -168,7 +168,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Encrypt_SamePlaintext_ShouldProduceDifferentCiphertext()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
         const string plaintext = "Test message";
 
         // Act
@@ -191,7 +191,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Encrypt_ThenDecrypt_ShouldReturnOriginalPlaintext(string plaintext)
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
 
         // Act
         var encrypted = provider.Encrypt(plaintext);
@@ -205,7 +205,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Encrypt_WithEmptyString_ShouldReturnEmptyString()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
 
         // Act
         var result = provider.Encrypt(string.Empty);
@@ -218,7 +218,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Encrypt_WithNewlineCharacters_ShouldEncryptAndDecryptCorrectly()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
         const string plaintext = "Line1\nLine2\r\nLine3";
 
         // Act
@@ -233,7 +233,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Encrypt_WithNull_ShouldReturnNull()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
 
         // Act
         var result = provider.Encrypt(null);
@@ -250,7 +250,7 @@ public class AesGcmColumnEncryptionProviderTests
     public void Encrypt_WithPlaintext_ShouldReturnBase64String(string plaintext)
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
 
         // Act
         var encrypted = provider.Encrypt(plaintext);
@@ -261,14 +261,14 @@ public class AesGcmColumnEncryptionProviderTests
         encrypted.Length.ShouldBeGreaterThan(0);
 
         // Verify it's valid base64
-        Should.NotThrow(() => Convert.FromBase64String(encrypted!));
+        Should.NotThrow(() => Convert.FromBase64String(encrypted));
     }
 
     [Fact]
     public void Encrypt_WithWhitespaceString_ShouldEncryptAndDecryptCorrectly()
     {
         // Arrange
-        var provider = new AesGcmColumnEncryptionProvider(this._validKey32);
+        var provider = new AesGcmColumnEncryptionProvider(_validKey32);
         const string plaintext = "   ";
 
         // Act

--- a/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateEdgeCaseTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateEdgeCaseTests.cs
@@ -38,7 +38,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
         foreach (var op in operators)
         {
             // Arrange
-            var builder = new DynamicPredicateBuilder()
+            var builder = new DynamicPredicateBuilder<Product>()
                 .With("Price", op, 100m);
 
             var (expression, parameters) = builder.Build();
@@ -66,7 +66,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
         foreach (var op in operators)
         {
             // Arrange
-            var builder = new DynamicPredicateBuilder()
+            var builder = new DynamicPredicateBuilder<Product>()
                 .With("Name", op, "Test");
 
             var (expression, parameters) = builder.Build();
@@ -83,7 +83,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithBooleanFalse_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, false);
 
         var (expression, parameters) = builder.Build();
@@ -99,7 +99,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithBooleanNotEqual_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.NotEqual, true);
 
         var (expression, parameters) = builder.Build();
@@ -115,7 +115,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithBooleanTrue_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, true);
 
         var (expression, parameters) = builder.Build();
@@ -131,7 +131,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithCaseSensitiveContains_ShouldRespectCase()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Name", FilterOperations.Contains, "PRODUCT");
 
         var (expression, parameters) = builder.Build();
@@ -147,7 +147,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithDecimalPrecision_ShouldMaintainPrecision()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Price", FilterOperations.Equal, 99.99m);
 
         var (expression, parameters) = builder.Build();
@@ -164,7 +164,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     {
         // Arrange
         var categoryName = _db.Categories.First().Name;
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Category.Name", FilterOperations.Equal, categoryName);
 
         var (expression, parameters) = builder.Build();
@@ -184,7 +184,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithEmptyString_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Name", FilterOperations.Equal, "");
 
         var (expression, parameters) = builder.Build();
@@ -200,7 +200,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithManyConditions_ShouldNotDegrade()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder();
+        var builder = new DynamicPredicateBuilder<Product>();
         for (var i = 0; i < 20; i++) builder.With("Price", FilterOperations.GreaterThan, i * 10m);
 
         // Act & Assert
@@ -215,7 +215,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithMaxDateTime_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("CreatedDate", FilterOperations.LessThan, DateTime.MaxValue);
 
         var (expression, parameters) = builder.Build();
@@ -231,7 +231,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithMaxDecimalValue_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Price", FilterOperations.LessThan, decimal.MaxValue);
 
         var (expression, parameters) = builder.Build();
@@ -247,7 +247,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithMinDateTime_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("CreatedDate", FilterOperations.GreaterThan, DateTime.MinValue);
 
         var (expression, parameters) = builder.Build();
@@ -263,7 +263,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithMixedNullAndNonNullConditions_ShouldHandleBoth()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.Equal, null)
             .With("Price", FilterOperations.GreaterThan, 100m)
             .With("Name", FilterOperations.NotEqual, null);
@@ -286,7 +286,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithNegativeValue_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Price", FilterOperations.GreaterThan, -100m);
 
         var (expression, parameters) = builder.Build();
@@ -302,7 +302,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithNotEqualNull_ShouldGenerateIsNotNullClause()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.NotEqual, null);
 
         var (expression, parameters) = builder.Build();
@@ -324,7 +324,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithNullValue_ShouldGenerateIsNullClause()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.Equal, null);
 
         var (expression, parameters) = builder.Build();
@@ -346,7 +346,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithNullValueInMiddle_ShouldMaintainCorrectParameterIndexing()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Price", FilterOperations.GreaterThan, 50m)
             .With("Description", FilterOperations.Equal, null)
             .With("StockQuantity", FilterOperations.LessThan, 100);
@@ -370,7 +370,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithSpecialCharactersInValue_ShouldEscape()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Name", FilterOperations.Contains, "%_[]");
 
         var (expression, parameters) = builder.Build();
@@ -386,7 +386,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithUnicodeCharacters_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Name", FilterOperations.Equal, "产品测试");
 
         var (expression, parameters) = builder.Build();
@@ -403,7 +403,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     {
         // Arrange
         var now = DateTime.UtcNow;
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("CreatedDate", FilterOperations.LessThanOrEqual, now);
 
         var (expression, parameters) = builder.Build();
@@ -419,7 +419,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithWhitespaceValue_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.Contains, "   ");
 
         var (expression, parameters) = builder.Build();
@@ -435,7 +435,7 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
     public void Build_WithZeroValue_ShouldWork()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("StockQuantity", FilterOperations.Equal, 0);
 
         var (expression, parameters) = builder.Build();
@@ -505,3 +505,4 @@ public class DynamicPredicateEdgeCaseTests : IClassFixture<TestDbFixture>
 
     #endregion
 }
+

--- a/src/EfCore/EfCore.Specifications.Tests/NullHandlingSqlVerificationTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/NullHandlingSqlVerificationTests.cs
@@ -45,7 +45,7 @@ public class NullHandlingSqlVerificationTests : IClassFixture<TestDbFixture>
     public void Build_NullHandling_WorksWithNavigationProperties()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Category.Description", FilterOperations.Equal, null);
 
         var (expression, parameters) = builder.Build();
@@ -65,7 +65,7 @@ public class NullHandlingSqlVerificationTests : IClassFixture<TestDbFixture>
     public void Build_WithMultipleNullConditions_GeneratesCorrectSql()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.Equal, null)
             .With("Name", FilterOperations.NotEqual, null);
 
@@ -85,7 +85,7 @@ public class NullHandlingSqlVerificationTests : IClassFixture<TestDbFixture>
     public void Build_WithNullAndRegularConditions_GeneratesCorrectParameterIndexing()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Price", FilterOperations.GreaterThan, 100m)
             .With("Description", FilterOperations.Equal, null)
             .With("IsActive", FilterOperations.Equal, true)
@@ -118,7 +118,7 @@ public class NullHandlingSqlVerificationTests : IClassFixture<TestDbFixture>
     public void Build_WithNullEqual_GeneratesIsNullInSql()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.Equal, null);
 
         var (expression, parameters) = builder.Build();
@@ -137,7 +137,7 @@ public class NullHandlingSqlVerificationTests : IClassFixture<TestDbFixture>
     public void Build_WithNullNotEqual_GeneratesIsNotNullInSql()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.NotEqual, null);
 
         var (expression, parameters) = builder.Build();
@@ -156,7 +156,7 @@ public class NullHandlingSqlVerificationTests : IClassFixture<TestDbFixture>
     public void Build_WithOnlyNullConditions_GeneratesNoParameters()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Description", FilterOperations.Equal, null)
             .With("Name", FilterOperations.NotEqual, null);
 

--- a/src/EfCore/EfCore.Specifications.Tests/PropertyNameExtensionsTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/PropertyNameExtensionsTests.cs
@@ -1,0 +1,51 @@
+namespace EfCore.Specifications.Tests;
+
+public class PropertyNameExtensionsTests
+{
+    #region Methods
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    [InlineData("foo", "Foo")]
+    [InlineData("fooBar", "FooBar")]
+    [InlineData("foo_bar", "FooBar")]
+    [InlineData("foo-bar", "FooBar")]
+    [InlineData("foo_bar-baz", "FooBarBaz")]
+    [InlineData("FOO_BAR", "FOOBAR")]
+    [InlineData("foo1_bar2", "Foo1Bar2")]
+    [InlineData("_foo_", "Foo")]
+    [InlineData("foo__bar", "FooBar")]
+    [InlineData("foo-bar_baz", "FooBarBaz")]
+    [InlineData("f", "F")]
+    [InlineData("f_b", "FB")]
+    public void ToPascalCase_WorksAsExpected(string input, string expected)
+    {
+        var result = input.ToPascalCase();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    [InlineData("foo", "Foo")]
+    [InlineData("foo.bar", "Foo.Bar")]
+    [InlineData("foo_bar.baz_qux", "FooBar.BazQux")]
+    [InlineData("foo-bar.baz-qux", "FooBar.BazQux")]
+    [InlineData("foo_bar-baz.qux_foo", "FooBarBaz.QuxFoo")]
+    [InlineData("foo.bar.baz", "Foo.Bar.Baz")]
+    [InlineData("foo1.bar2", "Foo1.Bar2")]
+    [InlineData("_foo_._bar_", "Foo.Bar")]
+    [InlineData("foo..bar", "Foo.Bar")]
+    [InlineData("foo-bar_baz.qux", "FooBarBaz.Qux")]
+    [InlineData("f.b", "F.B")]
+    public void ToPascalCasePath_WorksAsExpected(string input, string expected)
+    {
+        var result = input.ToPascalCase();
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Specifications.Tests/QueryStringVerificationTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/QueryStringVerificationTests.cs
@@ -26,7 +26,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void ComplexMultiConditionFilter_GeneratesAllConditions()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, true)
             .With("Price", FilterOperations.GreaterThan, 50m)
             .With("StockQuantity", FilterOperations.GreaterThan, 0)
@@ -55,7 +55,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     {
         // Arrange
         var cutoffDate = new DateTime(2024, 1, 1);
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("CreatedDate", FilterOperations.GreaterThanOrEqual, cutoffDate);
 
         var (expression, parameters) = builder.Build();
@@ -119,7 +119,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     {
         // Arrange
         var categoryName = _db.Categories.First().Name;
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Category.Name", FilterOperations.Equal, categoryName);
 
         var (expression, parameters) = builder.Build();
@@ -139,7 +139,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void NotEqualFilter_GeneratesNotEqualInSql()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.NotEqual, false);
 
         var (expression, parameters) = builder.Build();
@@ -156,7 +156,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void QueryWithGroupBy_GeneratesGroupByClause()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, true);
 
         var (expression, parameters) = builder.Build();
@@ -178,7 +178,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void QueryWithOrderBy_GeneratesOrderByClause()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, true);
 
         var (expression, parameters) = builder.Build();
@@ -198,7 +198,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void QueryWithProjection_GeneratesSelectWithSpecificColumns()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, true);
 
         var (expression, parameters) = builder.Build();
@@ -224,7 +224,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void QueryWithSkipTake_GeneratesOffsetFetch()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, true);
 
         var (expression, parameters) = builder.Build();
@@ -248,7 +248,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void RangeFilter_GeneratesCorrectSqlWithAndConditions()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Price", FilterOperations.GreaterThanOrEqual, 100m)
             .With("Price", FilterOperations.LessThanOrEqual, 500m);
 
@@ -268,7 +268,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void SimpleFilter_GeneratesCorrectSqlWithWhere()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("IsActive", FilterOperations.Equal, true);
 
         var (expression, parameters) = builder.Build();
@@ -288,7 +288,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void StringContainsFilter_GeneratesLikeInSql()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Name", FilterOperations.Contains, "Test");
 
         var (expression, parameters) = builder.Build();
@@ -307,7 +307,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void StringEndsWithFilter_GeneratesCorrectLikePattern()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Name", FilterOperations.EndsWith, "ing");
 
         var (expression, parameters) = builder.Build();
@@ -326,7 +326,7 @@ public class QueryStringVerificationTests : IClassFixture<TestDbFixture>
     public void StringStartsWithFilter_GeneratesCorrectLikePattern()
     {
         // Arrange
-        var builder = new DynamicPredicateBuilder()
+        var builder = new DynamicPredicateBuilder<Product>()
             .With("Name", FilterOperations.StartsWith, "Pro");
 
         var (expression, parameters) = builder.Build();

--- a/src/SlimBus/AspCore.SlimBus.Tests/ProblemDetailsExtensionsModelStateTests.cs
+++ b/src/SlimBus/AspCore.SlimBus.Tests/ProblemDetailsExtensionsModelStateTests.cs
@@ -17,7 +17,7 @@ public class ProblemDetailsExtensionsModelStateTests
         modelState.AddModelError("field2", "error2");
         var result = modelState.ToProblemDetails();
         result.ShouldNotBeNull();
-        result!.Status.ShouldBe((int)HttpStatusCode.BadRequest);
+        result.Status.ShouldBe((int)HttpStatusCode.BadRequest);
         result.Title.ShouldBe("Error");
         ((IEnumerable<string>)result.Extensions["errors"]!).Count().ShouldBe(2);
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the dynamic predicate builder and property name normalization logic in the specifications package, enhancing type safety, usability, and correctness when building dynamic LINQ predicates. The changes include making the `DynamicPredicateBuilder` generic, improving property type resolution and normalization, and updating extension methods to leverage these improvements. Minor test and settings cleanups are also included.

### Dynamic Predicate Builder Enhancements

* Refactored `DynamicPredicateBuilder` to be generic (`DynamicPredicateBuilder<TEntity>`), allowing property type resolution at build time and improving type safety for dynamic predicates. [[1]](diffhunk://#diff-d27e131e8e9e2559882dcab48c423d7f6edca160a7773f1fe9eac844c9dd8067L76-R77) [[2]](diffhunk://#diff-d27e131e8e9e2559882dcab48c423d7f6edca160a7773f1fe9eac844c9dd8067R127-R190) [[3]](diffhunk://#diff-d27e131e8e9e2559882dcab48c423d7f6edca160a7773f1fe9eac844c9dd8067L173-L179)
* Added logic to resolve property types from the entity type, automatically adjusting filter operations for non-string properties (e.g., switching `Contains` to `Equal` for enums and non-string types). [[1]](diffhunk://#diff-d27e131e8e9e2559882dcab48c423d7f6edca160a7773f1fe9eac844c9dd8067R87-R104) [[2]](diffhunk://#diff-d27e131e8e9e2559882dcab48c423d7f6edca160a7773f1fe9eac844c9dd8067R127-R190)

### Property Name Normalization Improvements

* Enhanced `ToPascalCase` extension to normalize dotted property paths, converting each segment to PascalCase and supporting underscores and hyphens as word boundaries. Internal helper methods were added for segment and path normalization. [[1]](diffhunk://#diff-af597c31f9960dc682feb598be491ec5db6970c2c793929f99661ea4fbcf0eefR13-R51) [[2]](diffhunk://#diff-af597c31f9960dc682feb598be491ec5db6970c2c793929f99661ea4fbcf0eefR64-R71)

### Extension Methods Update

* Updated all dynamic predicate extension methods (`DynamicAnd`, `DynamicOr`) to use the generic `DynamicPredicateBuilder<TEntity>`, ensuring correct type inference and property resolution. [[1]](diffhunk://#diff-49afb87ba7fb070cc04616d8d77e5a0894e77dc67249374d7f1be2aeee26d7f3L24-R26) [[2]](diffhunk://#diff-49afb87ba7fb070cc04616d8d77e5a0894e77dc67249374d7f1be2aeee26d7f3L50-R52) [[3]](diffhunk://#diff-49afb87ba7fb070cc04616d8d77e5a0894e77dc67249374d7f1be2aeee26d7f3L66-R67) [[4]](diffhunk://#diff-49afb87ba7fb070cc04616d8d77e5a0894e77dc67249374d7f1be2aeee26d7f3L82-R83) [[5]](diffhunk://#diff-49afb87ba7fb070cc04616d8d77e5a0894e77dc67249374d7f1be2aeee26d7f3L98-R99)

### Test and Settings Cleanup

* Simplified test assertions in `DtoMappingTests.cs` by removing unnecessary null-forgiving operators and ensuring direct property usage for attribute checks. [[1]](diffhunk://#diff-2aff784d7243347e4ac31537d1c8b82b02f1987ff95350d05a3c29d380a1bf75L59-R84) [[2]](diffhunk://#diff-2aff784d7243347e4ac31537d1c8b82b02f1987ff95350d05a3c29d380a1bf75L154-R172)
* Cleaned up user settings file by removing obsolete or inactive unit test session entries.