### PR TITLE
enhance the azure storage setup

### DIFF
--- a/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageOptions.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageOptions.cs
@@ -15,10 +15,15 @@ public class AzureStorageOptions : BlobServiceOptions
     #region Properties
 
     /// <summary>
+    ///     The factory method used to create the <see cref="BlobServiceClient" /> instance.
+    /// </summary>
+    public Func<AzureStorageOptions, Task<BlobServiceClient>>? BlobServiceClientFactory { get; set; }
+
+    /// <summary>
     ///     The Azure Storage connection string used to create a <c>BlobServiceClient</c>.
     ///     This value is required for the Azure provider to initialize correctly.
     /// </summary>
-    public string ConnectionString { get; set; } = null!;
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     ///     The container name to use for blob operations.

--- a/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageSetup.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageSetup.cs
@@ -21,6 +21,23 @@ public static class AzureStorageSetup
     ///     Registers the Azure storage adapter and binds <see cref="AzureStorageOptions" /> from configuration.
     /// </summary>
     /// <param name="services">The service collection to register services into.</param>
+    /// <param name="config">The configuration <see cref="AzureStorageOptions" /></param>
+    /// <returns>The updated <see cref="IServiceCollection" /> for chaining.</returns>
+    public static IServiceCollection AddAzureStorageAdapter(
+        this IServiceCollection services,
+        Action<AzureStorageOptions> config)
+    {
+        var option = new AzureStorageOptions();
+        config.Invoke(option);
+        return services
+            .AddSingleton(option)
+            .AddScoped<IBlobService, AzureStorageBlobService>();
+    }
+
+    /// <summary>
+    ///     Registers the Azure storage adapter and binds <see cref="AzureStorageOptions" /> from configuration.
+    /// </summary>
+    /// <param name="services">The service collection to register services into.</param>
     /// <param name="configuration">Application configuration used to bind provider options.</param>
     /// <returns>The updated <see cref="IServiceCollection" /> for chaining.</returns>
     public static IServiceCollection AddAzureStorageAdapter(


### PR DESCRIPTION
This pull request introduces improvements to the Azure Storage blob service, focusing on enhanced configurability and dependency injection support. The most notable changes are the addition of a factory method for creating `BlobServiceClient` instances, updates to option handling, and a new extension method for service registration.

**Configurability and Dependency Injection:**

* Added a `BlobServiceClientFactory` property to `AzureStorageOptions`, allowing consumers to inject custom logic for creating `BlobServiceClient` instances. The `ConnectionString` property is now nullable to support this flexibility.
* Refactored the client creation logic in `AzureStorageBlobService` to use either the provided `BlobServiceClientFactory` or fall back to the `ConnectionString`, improving support for advanced scenarios such as testing or custom authentication.

**Service Registration Improvements:**

* Introduced a new `AddAzureStorageAdapter` extension method in `AzureStorageSetup` for registering the Azure Storage adapter and binding options via code, simplifying setup and configuration in DI containers.

**Minor Documentation and Formatting Updates:**

* Fixed a minor typo in the XML documentation for the `DeleteAsync` method to clarify the return value.
* Improved formatting of the constructor in `AzureStorageBlobService` for better readability.