### PR TITLE
support in and not in operations

### DIFF
--- a/src/DKNet.FW.sln.DotSettings.user
+++ b/src/DKNet.FW.sln.DotSettings.user
@@ -576,6 +576,9 @@
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=8275c8a4_002D4ae3_002D406a_002D9cd0_002D6dc520603cf1/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;EfCore&amp;gt;\&amp;lt;EfCore.Specifications.Tests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/EfCore.Specifications.Tests" Presentation="&amp;lt;EfCore&amp;gt;\&amp;lt;EfCore.Specifications.Tests&amp;gt;" /&gt;
 &lt;/SessionState&gt;</s:String>
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd8ac265_002D8b5d_002D4892_002D9e95_002Dccb01cb363e1/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;EfCore&amp;gt;\&amp;lt;EfCore.Specifications.Tests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src" Presentation="&amp;lt;EfCore&amp;gt;" /&gt;
+&lt;/SessionState&gt;</s:String>
 	
 	
 	

--- a/src/EfCore/DKNet.EfCore.Specifications/Dynamics/Ops.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Dynamics/Ops.cs
@@ -3,7 +3,7 @@ namespace DKNet.EfCore.Specifications.Dynamics;
 /// <summary>
 ///     Defines the supported operations for building dynamic predicates.
 /// </summary>
-public enum DynamicOperations
+public enum Ops
 {
     /// <summary>
     ///     Equality comparison (==)
@@ -53,5 +53,21 @@ public enum DynamicOperations
     /// <summary>
     ///     String ends with operation
     /// </summary>
-    EndsWith
+    EndsWith,
+
+    /// <summary>
+    ///     Checks if the property value is contained in a collection of values.
+    ///     Requires value to be an array or IEnumerable (excluding string).
+    ///     Translates to SQL IN clause.
+    ///     Example: CategoryId IN (1, 2, 3)
+    /// </summary>
+    In,
+
+    /// <summary>
+    ///     Checks if the property value is NOT contained in a collection of values.
+    ///     Requires value to be an array or IEnumerable (excluding string).
+    ///     Translates to SQL NOT IN clause.
+    ///     Example: CategoryId NOT IN (1, 2, 3)
+    /// </summary>
+    NotIn
 }

--- a/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateBuilderExtensionsTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateBuilderExtensionsTests.cs
@@ -28,7 +28,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var boolType = typeof(bool);
 
         // Act & Assert
-        boolType.AdjustOperationForValueType(DynamicOperations.Contains).ShouldBe(DynamicOperations.Equal);
+        boolType.AdjustOperationForValueType(Ops.Contains).ShouldBe(Ops.Equal);
     }
 
     [Fact]
@@ -38,10 +38,10 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var intType = typeof(int);
 
         // Act & Assert: Comparison operations should not change
-        intType.AdjustOperationForValueType(DynamicOperations.Equal).ShouldBe(DynamicOperations.Equal);
-        intType.AdjustOperationForValueType(DynamicOperations.NotEqual).ShouldBe(DynamicOperations.NotEqual);
-        intType.AdjustOperationForValueType(DynamicOperations.GreaterThan).ShouldBe(DynamicOperations.GreaterThan);
-        intType.AdjustOperationForValueType(DynamicOperations.LessThan).ShouldBe(DynamicOperations.LessThan);
+        intType.AdjustOperationForValueType(Ops.Equal).ShouldBe(Ops.Equal);
+        intType.AdjustOperationForValueType(Ops.NotEqual).ShouldBe(Ops.NotEqual);
+        intType.AdjustOperationForValueType(Ops.GreaterThan).ShouldBe(Ops.GreaterThan);
+        intType.AdjustOperationForValueType(Ops.LessThan).ShouldBe(Ops.LessThan);
     }
 
     [Fact]
@@ -51,7 +51,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var decimalType = typeof(decimal);
 
         // Act & Assert
-        decimalType.AdjustOperationForValueType(DynamicOperations.Contains).ShouldBe(DynamicOperations.Equal);
+        decimalType.AdjustOperationForValueType(Ops.Contains).ShouldBe(Ops.Equal);
     }
 
     [Fact]
@@ -61,8 +61,8 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var enumType = typeof(OrderStatus);
 
         // Act & Assert
-        enumType.AdjustOperationForValueType(DynamicOperations.Contains).ShouldBe(DynamicOperations.Equal);
-        enumType.AdjustOperationForValueType(DynamicOperations.NotContains).ShouldBe(DynamicOperations.NotEqual);
+        enumType.AdjustOperationForValueType(Ops.Contains).ShouldBe(Ops.Equal);
+        enumType.AdjustOperationForValueType(Ops.NotContains).ShouldBe(Ops.NotEqual);
     }
 
     [Fact]
@@ -72,10 +72,10 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var intType = typeof(int);
 
         // Act & Assert
-        intType.AdjustOperationForValueType(DynamicOperations.Contains).ShouldBe(DynamicOperations.Equal);
-        intType.AdjustOperationForValueType(DynamicOperations.NotContains).ShouldBe(DynamicOperations.NotEqual);
-        intType.AdjustOperationForValueType(DynamicOperations.StartsWith).ShouldBe(DynamicOperations.Equal);
-        intType.AdjustOperationForValueType(DynamicOperations.EndsWith).ShouldBe(DynamicOperations.Equal);
+        intType.AdjustOperationForValueType(Ops.Contains).ShouldBe(Ops.Equal);
+        intType.AdjustOperationForValueType(Ops.NotContains).ShouldBe(Ops.NotEqual);
+        intType.AdjustOperationForValueType(Ops.StartsWith).ShouldBe(Ops.Equal);
+        intType.AdjustOperationForValueType(Ops.EndsWith).ShouldBe(Ops.Equal);
     }
 
     [Fact]
@@ -85,7 +85,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var nullableStringType = typeof(string);
 
         // Act & Assert
-        nullableStringType.AdjustOperationForValueType(DynamicOperations.Contains).ShouldBe(DynamicOperations.Contains);
+        nullableStringType.AdjustOperationForValueType(Ops.Contains).ShouldBe(Ops.Contains);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         Type? nullType = null;
 
         // Act & Assert
-        nullType.AdjustOperationForValueType(DynamicOperations.Contains).ShouldBe(DynamicOperations.Contains);
+        nullType.AdjustOperationForValueType(Ops.Contains).ShouldBe(Ops.Contains);
     }
 
     [Fact]
@@ -105,17 +105,17 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var stringType = typeof(string);
 
         // Act & Assert: String operations should remain unchanged
-        stringType.AdjustOperationForValueType(DynamicOperations.Contains).ShouldBe(DynamicOperations.Contains);
-        stringType.AdjustOperationForValueType(DynamicOperations.StartsWith).ShouldBe(DynamicOperations.StartsWith);
-        stringType.AdjustOperationForValueType(DynamicOperations.EndsWith).ShouldBe(DynamicOperations.EndsWith);
-        stringType.AdjustOperationForValueType(DynamicOperations.NotContains).ShouldBe(DynamicOperations.NotContains);
+        stringType.AdjustOperationForValueType(Ops.Contains).ShouldBe(Ops.Contains);
+        stringType.AdjustOperationForValueType(Ops.StartsWith).ShouldBe(Ops.StartsWith);
+        stringType.AdjustOperationForValueType(Ops.EndsWith).ShouldBe(Ops.EndsWith);
+        stringType.AdjustOperationForValueType(Ops.NotContains).ShouldBe(Ops.NotContains);
     }
 
     [Fact]
     public void BuildClause_Contains_GeneratesCorrectClause()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.Contains, "test", 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.Contains, "test", 0);
 
         // Assert
         clause.ShouldBe("Name.Contains(@0)");
@@ -125,7 +125,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_EndsWith_GeneratesCorrectClause()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.EndsWith, "test", 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.EndsWith, "test", 0);
 
         // Assert
         clause.ShouldBe("Name.EndsWith(@0)");
@@ -135,7 +135,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_Equal_WithNull_GeneratesNullCheck()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.Equal, null, 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.Equal, null, 0);
 
         // Assert
         clause.ShouldBe("Name == null");
@@ -145,7 +145,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_Equal_WithValue_GeneratesCorrectClause()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.Equal, "test", 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.Equal, "test", 0);
 
         // Assert
         clause.ShouldBe("Name == @0");
@@ -155,7 +155,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_GreaterThan_GeneratesCorrectClause()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Price", DynamicOperations.GreaterThan, 100, 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Price", Ops.GreaterThan, 100, 0);
 
         // Assert
         clause.ShouldBe("Price > @0");
@@ -165,7 +165,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_LessThan_GeneratesCorrectClause()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Price", DynamicOperations.LessThan, 100, 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Price", Ops.LessThan, 100, 0);
 
         // Assert
         clause.ShouldBe("Price < @0");
@@ -175,9 +175,9 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_MultipleParameters_UsesCorrectIndex()
     {
         // Arrange & Act
-        var clause1 = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.Equal, "test", 0);
-        var clause2 = DynamicPredicateBuilderExtensions.BuildClause("Price", DynamicOperations.GreaterThan, 100, 1);
-        var clause3 = DynamicPredicateBuilderExtensions.BuildClause("IsActive", DynamicOperations.Equal, true, 2);
+        var clause1 = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.Equal, "test", 0);
+        var clause2 = DynamicPredicateBuilderExtensions.BuildClause("Price", Ops.GreaterThan, 100, 1);
+        var clause3 = DynamicPredicateBuilderExtensions.BuildClause("IsActive", Ops.Equal, true, 2);
 
         // Assert
         clause1.ShouldBe("Name == @0");
@@ -189,7 +189,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_NotContains_GeneratesCorrectClause()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.NotContains, "test", 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.NotContains, "test", 0);
 
         // Assert
         clause.ShouldBe("!Name.Contains(@0)");
@@ -199,7 +199,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_NotEqual_WithNull_GeneratesNotNullCheck()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.NotEqual, null, 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.NotEqual, null, 0);
 
         // Assert
         clause.ShouldBe("Name != null");
@@ -209,7 +209,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     public void BuildClause_StartsWith_GeneratesCorrectClause()
     {
         // Arrange & Act
-        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", DynamicOperations.StartsWith, "test", 0);
+        var clause = DynamicPredicateBuilderExtensions.BuildClause("Name", Ops.StartsWith, "test", 0);
 
         // Assert
         clause.ShouldBe("Name.StartsWith(@0)");
@@ -220,7 +220,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
     {
         // Arrange & Act & Assert
         Should.Throw<NotSupportedException>(() =>
-            DynamicPredicateBuilderExtensions.BuildClause("Name", (DynamicOperations)999, "test", 0));
+            DynamicPredicateBuilderExtensions.BuildClause("Name", (Ops)999, "test", 0));
     }
 
     [Fact]
@@ -231,9 +231,9 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
 
         // Act: Test case-insensitive property names
         var result = predicate
-            .DynamicAnd("name", DynamicOperations.Contains, "test") // lowercase
-            .DynamicAnd("PRICE", DynamicOperations.GreaterThan, 100) // uppercase
-            .DynamicAnd("IsActive", DynamicOperations.Equal, true); // PascalCase
+            .DynamicAnd("name", Ops.Contains, "test") // lowercase
+            .DynamicAnd("PRICE", Ops.GreaterThan, 100) // uppercase
+            .DynamicAnd("IsActive", Ops.Equal, true); // PascalCase
 
         // Assert
         var query = _context.Products.AsExpandable().Where(result);
@@ -250,7 +250,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var predicate = PredicateBuilder.New<Order>(o => o.Id > 0);
 
         // Act: Try to filter with invalid enum value
-        var result = predicate.DynamicAnd("Status", DynamicOperations.Equal, "InvalidEnumValue");
+        var result = predicate.DynamicAnd("Status", Ops.Equal, "InvalidEnumValue");
 
         // Assert: Should ignore invalid enum
         var query = _context.Orders.AsExpandable().Where(result);
@@ -265,7 +265,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
 
         // Act
-        var result = predicate.DynamicAnd("NonExistentProperty", DynamicOperations.Equal, "test");
+        var result = predicate.DynamicAnd("NonExistentProperty", Ops.Equal, "test");
 
         // Assert: Should return original predicate unchanged
         var query = _context.Products.AsExpandable().Where(result);
@@ -281,7 +281,7 @@ public class DynamicPredicateBuilderExtensionsTests(TestDbFixture fixture) : ICl
         var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
 
         // Act
-        var result = predicate.DynamicOr("NonExistentProperty", DynamicOperations.Equal, "test");
+        var result = predicate.DynamicOr("NonExistentProperty", Ops.Equal, "test");
 
         // Assert
         var query = _context.Products.AsExpandable().Where(result);

--- a/src/EfCore/EfCore.Specifications.Tests/SpecFilterTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/SpecFilterTests.cs
@@ -28,7 +28,7 @@ internal sealed class ProductFilterSpecification : Specification<Product>
         // Build sub-predicate for all fields
         var searchPredicator = PredicateBuilder.New<Product>();
         foreach (var f in fields)
-            searchPredicator = searchPredicator.DynamicOr(f, DynamicOperations.Contains, searchString);
+            searchPredicator = searchPredicator.DynamicOr(f, Ops.Contains, searchString);
 
         predicate = predicate.And(searchPredicator);
         WithFilter(predicate);

--- a/src/plan-inNotInOperations.prompt.md
+++ b/src/plan-inNotInOperations.prompt.md
@@ -1,0 +1,588 @@
+# Plan: Add `In` and `NotIn` Array Operations to DynamicOperations
+
+## Overview
+
+Add support for SQL `IN` and `NOT IN` operations to the dynamic predicate system using **System.Linq.Dynamic.Core's `DynamicExpressionParser.ParseLambda`** exclusively. This ensures parameterized queries and prevents SQL injection while maintaining the existing safety patterns.
+
+**Security Requirement**: All expression building **MUST** go through `DynamicExpressionParser.ParseLambda` with values as parameters (`@0`, `@1`, etc.) - never string concatenation or manual expression tree construction for user input.
+
+## Goals
+
+1. Enable runtime filtering against collections of values (e.g., `WHERE CategoryId IN (1, 2, 3)`)
+2. Maintain type safety and null-safe graceful degradation patterns
+3. Ensure EF Core translates expressions to optimal SQL `IN` clauses
+4. Prevent SQL injection by exclusively using `DynamicExpressionParser.ParseLambda`
+5. Support arrays, lists, and any `IEnumerable<T>` collection types
+6. Maintain consistency with existing `DynamicOperations` patterns
+
+## Implementation Steps
+
+### Step 1: Add Enum Values to `DynamicOperations.cs`
+
+**File**: `/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicOperations.cs`
+
+**Changes**:
+- Add `In = 10` enum member with XML documentation
+- Add `NotIn = 11` enum member with XML documentation
+- Document that these operations require array/collection values (`IEnumerable<T>`)
+
+**Example**:
+```csharp
+/// <summary>
+///     Checks if the property value is contained in a collection of values.
+///     Requires value to be an array or IEnumerable (excluding string).
+///     Translates to SQL IN clause.
+/// </summary>
+In = 10,
+
+/// <summary>
+///     Checks if the property value is NOT contained in a collection of values.
+///     Requires value to be an array or IEnumerable (excluding string).
+///     Translates to SQL NOT IN clause.
+/// </summary>
+NotIn = 11
+```
+
+### Step 2: Add Array Validation Helper to `DynamicPredicateBuilderExtensions.cs`
+
+**File**: `/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateBuilderExtensions.cs`
+
+**Changes**:
+- Add `ValidateArrayValue` internal extension method
+- Check if value implements `IEnumerable` (excluding `string`)
+- Verify collection is non-empty
+- Return `false` for null, empty, or non-enumerable values
+
+**Implementation**:
+```csharp
+/// <summary>
+///     Validates if a value is a valid array/collection for In/NotIn operations.
+///     Returns false for null, empty collections, or non-enumerable types (including string).
+/// </summary>
+/// <param name="value">The value to validate</param>
+/// <param name="operation">The operation being performed</param>
+/// <returns>True if value is valid for the operation, false otherwise</returns>
+internal static bool ValidateArrayValue(object? value, DynamicOperations operation)
+{
+    // Only validate for In/NotIn operations
+    if (operation is not (DynamicOperations.In or DynamicOperations.NotIn))
+        return true;
+
+    if (value == null)
+        return false;
+
+    // String implements IEnumerable but should not be treated as array
+    if (value is string)
+        return false;
+
+    // Check if value is enumerable
+    if (value is not IEnumerable enumerable)
+        return false;
+
+    // Check if collection is non-empty
+    var enumerator = enumerable.GetEnumerator();
+    var hasElements = enumerator.MoveNext();
+    (enumerator as IDisposable)?.Dispose();
+
+    return hasElements;
+}
+```
+
+### Step 3: Update `BuildClause` Method in `DynamicPredicateBuilderExtensions.cs`
+
+**File**: `/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateBuilderExtensions.cs`
+
+**Changes**:
+- Add cases for `In` and `NotIn` in the operation switch statement
+- Generate System.Linq.Dynamic.Core syntax: `@0.Contains(PropertyName)` for `In`
+- Generate System.Linq.Dynamic.Core syntax: `!@0.Contains(PropertyName)` for `NotIn`
+- Ensure array is passed as `@0` parameter to `DynamicExpressionParser.ParseLambda`
+
+**Implementation**:
+```csharp
+internal static string BuildClause(string prop, DynamicOperations op, object? val, int paramIndex)
+{
+    return val switch
+    {
+        null when op is DynamicOperations.Equal => $"{prop} == null",
+        null when op is DynamicOperations.NotEqual => $"{prop} != null",
+        _ => op switch
+        {
+            DynamicOperations.Equal => $"{prop} == @{paramIndex}",
+            DynamicOperations.NotEqual => $"{prop} != @{paramIndex}",
+            DynamicOperations.GreaterThan => $"{prop} > @{paramIndex}",
+            DynamicOperations.GreaterThanOrEqual => $"{prop} >= @{paramIndex}",
+            DynamicOperations.LessThan => $"{prop} < @{paramIndex}",
+            DynamicOperations.LessThanOrEqual => $"{prop} <= @{paramIndex}",
+            DynamicOperations.Contains => $"{prop}.Contains(@{paramIndex})",
+            DynamicOperations.NotContains => $"!{prop}.Contains(@{paramIndex})",
+            DynamicOperations.StartsWith => $"{prop}.StartsWith(@{paramIndex})",
+            DynamicOperations.EndsWith => $"{prop}.EndsWith(@{paramIndex})",
+            DynamicOperations.In => $"@{paramIndex}.Contains({prop})",        // Array contains property value
+            DynamicOperations.NotIn => $"!@{paramIndex}.Contains({prop})",    // Array does NOT contain property value
+            _ => throw new NotSupportedException($"Operation {op} not supported.")
+        }
+    };
+}
+```
+
+**Note**: The syntax `@0.Contains(PropertyName)` tells System.Linq.Dynamic.Core to generate an expression where the array parameter (`@0`) contains the property value, which EF Core translates to SQL `IN`.
+
+### Step 4: Update `AdjustOperationForValueType` (No Changes Needed)
+
+**File**: `/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateBuilderExtensions.cs`
+
+**Analysis**: 
+- `In` and `NotIn` operations should NOT be adjusted based on property type
+- They work with all types (int, string, enum, DateTime, etc.)
+- The validation happens at the value level (must be array), not property type level
+- **No changes required** to this method
+
+### Step 5: Enhance `BuildDynamicExpression` in `DynamicPredicateExtensions.cs`
+
+**File**: `/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateExtensions.cs`
+
+**Changes**:
+- Add array validation before calling `BuildClause` for `In`/`NotIn` operations
+- Return `null` if array validation fails (triggers null-safe fallback)
+- Ensure only valid collections reach `DynamicExpressionParser.ParseLambda`
+
+**Implementation**:
+```csharp
+private static Expression<Func<T, bool>>? BuildDynamicExpression<T>(string propertyName,
+    DynamicOperations operation, object? value)
+{
+    // Normalize property path using PropertyNameExtensions (PascalCase each segment)
+    var normalizedPath = propertyName.ToPascalCase();
+
+    var propType = typeof(T).ResolvePropertyType(normalizedPath);
+    if (propType == null)
+        return null;
+
+    // Validate array value for In/NotIn operations
+    if (!DynamicPredicateBuilderExtensions.ValidateArrayValue(value, operation))
+        return null;
+
+    // Adjust operation for type (In/NotIn are not adjusted)
+    var op = propType.AdjustOperationForValueType(operation);
+
+    // Validate enum value if needed
+    if (!propType.ValidateEnumValue(value))
+        return null;
+
+    // Build the dynamic LINQ predicate string using shared BuildClause method
+    var predicateString = DynamicPredicateBuilderExtensions.BuildClause(normalizedPath, op, value, 0);
+
+    try
+    {
+        // Use System.Linq.Dynamic.Core to parse the predicate string
+        // For In/NotIn, value is the array passed as @0 parameter
+        var lambda = value == null
+            ? DynamicExpressionParser.ParseLambda<T, bool>(ParsingConfig.Default, false, predicateString)
+            : DynamicExpressionParser.ParseLambda<T, bool>(ParsingConfig.Default, false, predicateString, value);
+
+        return lambda;
+    }
+#pragma warning disable CA1031 // Do not catch general exception types - DynamicExpressionParser can throw various exception types
+    catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+    {
+        // If parsing fails, return null (invalid expression)
+        return null;
+    }
+}
+```
+
+### Step 6: Write Comprehensive Unit Tests
+
+**File**: `/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateExtensionsAdvancedTests.cs`
+
+**Test Cases**:
+
+#### Test 1: In Operation with Int Array
+```csharp
+[Fact]
+public async Task DynamicAnd_WithInOperation_IntArray_ReturnsMatchingRecords()
+{
+    // Arrange
+    var categoryIds = new[] { 1, 2, 3 };
+    var predicate = PredicateBuilder.New<Product>(true)
+        .DynamicAnd("CategoryId", DynamicOperations.In, categoryIds);
+
+    // Act
+    var results = await _context.Products
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    results.ShouldNotBeEmpty();
+    results.ShouldAllBe(p => categoryIds.Contains(p.CategoryId));
+    
+    // Verify SQL contains IN clause
+    var query = _context.Products.AsExpandable().Where(predicate);
+    var sql = query.ToQueryString();
+    sql.ShouldContain("IN"); // SQL Server IN clause
+}
+```
+
+#### Test 2: NotIn Operation with String Array
+```csharp
+[Fact]
+public async Task DynamicAnd_WithNotInOperation_StringArray_ExcludesRecords()
+{
+    // Arrange
+    var excludedNames = new[] { "Product A", "Product B" };
+    var predicate = PredicateBuilder.New<Product>(true)
+        .DynamicAnd("Name", DynamicOperations.NotIn, excludedNames);
+
+    // Act
+    var results = await _context.Products
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    results.ShouldNotBeEmpty();
+    results.ShouldAllBe(p => !excludedNames.Contains(p.Name));
+}
+```
+
+#### Test 3: In Operation with Enum Array
+```csharp
+[Fact]
+public async Task DynamicAnd_WithInOperation_EnumArray_ReturnsMatchingRecords()
+{
+    // Arrange
+    var statuses = new[] { OrderStatus.Pending, OrderStatus.Processing };
+    var predicate = PredicateBuilder.New<Order>(true)
+        .DynamicAnd("Status", DynamicOperations.In, statuses);
+
+    // Act
+    var results = await _context.Orders
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    results.ShouldNotBeEmpty();
+    results.ShouldAllBe(o => statuses.Contains(o.Status));
+}
+```
+
+#### Test 4: In Operation with Enum Int Array
+```csharp
+[Fact]
+public async Task DynamicAnd_WithInOperation_EnumIntArray_ReturnsMatchingRecords()
+{
+    // Arrange - Using int values for enum
+    var statusValues = new[] { 0, 1 }; // Pending = 0, Processing = 1
+    var predicate = PredicateBuilder.New<Order>(true)
+        .DynamicAnd("Status", DynamicOperations.In, statusValues);
+
+    // Act
+    var results = await _context.Orders
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    results.ShouldNotBeEmpty();
+    results.ShouldAllBe(o => statusValues.Contains((int)o.Status));
+}
+```
+
+#### Test 5: Empty Array Handling
+```csharp
+[Fact]
+public void DynamicAnd_WithInOperation_EmptyArray_ReturnsOriginalPredicate()
+{
+    // Arrange
+    var emptyArray = Array.Empty<int>();
+    var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+    // Act
+    var result = predicate.DynamicAnd("CategoryId", DynamicOperations.In, emptyArray);
+
+    // Assert
+    // Empty array should be invalid, so original predicate is returned
+    var query = _context.Products.AsExpandable().Where(result);
+    var sql = query.ToQueryString();
+    sql.ShouldNotContain("IN"); // Should not have IN clause
+    sql.ShouldContain("[IsActive]"); // Should only have original condition
+}
+```
+
+#### Test 6: Null Array Handling
+```csharp
+[Fact]
+public void DynamicAnd_WithInOperation_NullArray_ReturnsOriginalPredicate()
+{
+    // Arrange
+    var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+    // Act
+    var result = predicate.DynamicAnd("CategoryId", DynamicOperations.In, null);
+
+    // Assert
+    var query = _context.Products.AsExpandable().Where(result);
+    var sql = query.ToQueryString();
+    sql.ShouldNotContain("IN");
+    sql.ShouldContain("[IsActive]");
+}
+```
+
+#### Test 7: Single Value Array
+```csharp
+[Fact]
+public async Task DynamicAnd_WithInOperation_SingleValueArray_ReturnsMatchingRecord()
+{
+    // Arrange
+    var singleCategoryId = new[] { 1 };
+    var predicate = PredicateBuilder.New<Product>(true)
+        .DynamicAnd("CategoryId", DynamicOperations.In, singleCategoryId);
+
+    // Act
+    var results = await _context.Products
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    results.ShouldAllBe(p => p.CategoryId == 1);
+}
+```
+
+#### Test 8: List<T> Support
+```csharp
+[Fact]
+public async Task DynamicAnd_WithInOperation_List_ReturnsMatchingRecords()
+{
+    // Arrange
+    var categoryIdsList = new List<int> { 1, 2, 3 };
+    var predicate = PredicateBuilder.New<Product>(true)
+        .DynamicAnd("CategoryId", DynamicOperations.In, categoryIdsList);
+
+    // Act
+    var results = await _context.Products
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    results.ShouldNotBeEmpty();
+    results.ShouldAllBe(p => categoryIdsList.Contains(p.CategoryId));
+}
+```
+
+#### Test 9: SQL Injection Prevention Test
+```csharp
+[Fact]
+public async Task DynamicAnd_WithInOperation_MaliciousInput_SafelyParameterized()
+{
+    // Arrange - Attempt SQL injection via array values
+    var maliciousValues = new[] { "Product'; DROP TABLE Products--", "Normal Product" };
+    var predicate = PredicateBuilder.New<Product>(true)
+        .DynamicAnd("Name", DynamicOperations.In, maliciousValues);
+
+    // Act
+    var results = await _context.Products
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    // Should safely parameterize and treat as literal string value
+    // Products table should still exist
+    var allProducts = await _context.Products.ToListAsync();
+    allProducts.ShouldNotBeEmpty(); // Table not dropped
+    
+    // Verify SQL uses parameters
+    var query = _context.Products.AsExpandable().Where(predicate);
+    var sql = query.ToQueryString();
+    sql.ShouldNotContain("DROP TABLE"); // Malicious SQL not injected
+}
+```
+
+#### Test 10: Chained In/NotIn Operations
+```csharp
+[Fact]
+public async Task DynamicAnd_CombinedInAndNotIn_ReturnsCorrectRecords()
+{
+    // Arrange
+    var includedCategories = new[] { 1, 2, 3 };
+    var excludedNames = new[] { "Excluded Product" };
+    
+    var predicate = PredicateBuilder.New<Product>(true)
+        .DynamicAnd("CategoryId", DynamicOperations.In, includedCategories)
+        .DynamicAnd("Name", DynamicOperations.NotIn, excludedNames);
+
+    // Act
+    var results = await _context.Products
+        .AsExpandable()
+        .Where(predicate)
+        .ToListAsync();
+
+    // Assert
+    results.ShouldAllBe(p => 
+        includedCategories.Contains(p.CategoryId) && 
+        !excludedNames.Contains(p.Name));
+}
+```
+
+#### Test 11: String as Array (Should Fail Validation)
+```csharp
+[Fact]
+public void DynamicAnd_WithInOperation_StringValue_ReturnsOriginalPredicate()
+{
+    // Arrange - String should NOT be treated as array even though it's IEnumerable<char>
+    var stringValue = "test";
+    var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+    // Act
+    var result = predicate.DynamicAnd("Name", DynamicOperations.In, stringValue);
+
+    // Assert
+    var query = _context.Products.AsExpandable().Where(result);
+    var sql = query.ToQueryString();
+    sql.ShouldNotContain("IN");
+    sql.ShouldContain("[IsActive]");
+}
+```
+
+### Step 7: Add Integration Test for SQL Generation
+
+**File**: `/Users/steven/_CODE/DRUNK/DKNet/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateExtensionsAdvancedTests.cs`
+
+**Test Case**:
+```csharp
+[Fact]
+public void DynamicAnd_WithInOperation_GeneratesParameterizedInClause()
+{
+    // Arrange
+    var categoryIds = new[] { 1, 2, 3 };
+    var predicate = PredicateBuilder.New<Product>(true)
+        .DynamicAnd("CategoryId", DynamicOperations.In, categoryIds);
+
+    // Act
+    var query = _context.Products.AsExpandable().Where(predicate);
+    var sql = query.ToQueryString();
+
+    // Assert - Verify SQL is parameterized
+    sql.ShouldContain("IN"); // Has IN clause
+    sql.ShouldNotContain("IN (1, 2, 3)"); // NOT hard-coded values
+    sql.ShouldMatch(@"IN\s*\(@__"); // Should have parameter like @__p_0
+    
+    // Verify it's a valid SQL query
+    sql.ShouldContain("SELECT");
+    sql.ShouldContain("FROM [Products]");
+}
+```
+
+## Testing Strategy
+
+### Unit Tests (DynamicPredicateBuilderExtensionsTests.cs)
+1. Test `ValidateArrayValue` with various inputs:
+   - Null value → returns `false`
+   - Empty array → returns `false`
+   - String value → returns `false`
+   - Non-enumerable → returns `false`
+   - Valid array → returns `true`
+   - Valid List<T> → returns `true`
+
+### Integration Tests (DynamicPredicateExtensionsAdvancedTests.cs)
+1. Test SQL generation with TestContainers (real SQL Server)
+2. Verify parameterization prevents SQL injection
+3. Test with different collection types (array, List, IEnumerable)
+4. Test with different data types (int, string, enum, DateTime)
+5. Test edge cases (empty, null, single value)
+6. Test chained operations (In + NotIn, In + other filters)
+
+## Security Considerations
+
+### SQL Injection Prevention
+- **CRITICAL**: All expression building uses `DynamicExpressionParser.ParseLambda` with parameters
+- Array values are passed as `@0` parameter, not concatenated into SQL string
+- Malicious array values (e.g., `["value'; DROP TABLE--"]`) are safely parameterized
+- No manual SQL string construction or concatenation
+
+### Type Safety
+- Array element types should match property type for optimal SQL generation
+- Runtime type validation by `DynamicExpressionParser.ParseLambda`
+- Invalid types return `null` expression (graceful degradation)
+
+## Performance Considerations
+
+### Large Arrays
+- SQL Server has limits on IN clause size (typically 2000+ values is problematic)
+- Consider documenting recommended max array size (e.g., 100-500 values)
+- For very large sets, recommend alternative approaches (temp tables, table-valued parameters)
+- **Decision**: Leave validation to caller, document in XML comments
+
+### SQL Generation
+- System.Linq.Dynamic.Core generates: `@0.Contains(PropertyName)`
+- EF Core translates to: `WHERE PropertyName IN (@p0, @p1, @p2...)`
+- Each array element becomes a separate parameter
+- Performance is comparable to hand-written LINQ `Where(p => ids.Contains(p.Id))`
+
+## Open Questions for Refinement
+
+1. **Empty Array Behavior**: 
+   - Current: Returns `null` expression (original predicate unchanged)
+   - Alternative: Could generate `WHERE 1=0` for `In`, `WHERE 1=1` for `NotIn`
+   - **Recommendation**: Keep current null-safe behavior for consistency
+
+2. **Array Size Limits**:
+   - Should we validate/warn for arrays > 1000 elements?
+   - **Recommendation**: Document in XML comments, leave to caller
+
+3. **String Array Case Sensitivity**:
+   - Should `In` on string arrays be case-insensitive by default?
+   - **Recommendation**: Follow SQL Server default (case-insensitive), add separate operation for case-sensitive later if needed
+
+4. **IQueryable<T> Support**:
+   - Should we support `IQueryable<int>` as value (subquery)?
+   - **Recommendation**: Out of scope for now, document limitation
+
+## Documentation Updates
+
+### XML Documentation
+- Update `DynamicOperations` enum with detailed In/NotIn documentation
+- Document array requirement in method XML comments
+- Add examples in XML `<example>` tags showing array usage
+- Document performance considerations for large arrays
+
+### README/Wiki
+- Add section on In/NotIn operations with code examples
+- Document SQL injection safety via `DynamicExpressionParser.ParseLambda`
+- Show comparison with hand-written LINQ: `Where(p => ids.Contains(p.Id))`
+
+## Success Criteria
+
+- ✅ `In` and `NotIn` enum values added with XML documentation
+- ✅ Array validation implemented and tested
+- ✅ `BuildClause` supports In/NotIn with correct Dynamic LINQ syntax
+- ✅ All expressions use `DynamicExpressionParser.ParseLambda` (no SQL injection)
+- ✅ 11+ unit/integration tests passing with TestContainers
+- ✅ SQL generation verified to produce parameterized IN clauses
+- ✅ Zero compilation warnings (`TreatWarningsAsErrors=true`)
+- ✅ Code coverage > 85% for new code
+- ✅ SQL injection prevention test passes
+
+## Implementation Order
+
+1. Add enum values (simplest, establishes contract)
+2. Add array validation helper (supports validation logic)
+3. Update `BuildClause` (core functionality)
+4. Update `BuildDynamicExpression` (integration point)
+5. Write unit tests (validate each piece)
+6. Write integration tests (validate end-to-end)
+7. Add SQL injection test (security validation)
+8. Update documentation (knowledge sharing)
+
+---
+
+**Total Estimated Effort**: 3-4 hours
+**Risk Level**: Low (follows existing patterns, uses proven library)
+**Dependencies**: System.Linq.Dynamic.Core (already in use)
+


### PR DESCRIPTION
This pull request refactors and extends dynamic predicate building for EF Core specifications, focusing on operation handling and validation for array and enum types. The most significant change is the renaming and enhancement of the dynamic operations enum, adding support for `In` and `NotIn` operations, and updating all related code and tests to use the new `Ops` enum. The changes also introduce robust validation for array and enum values in dynamic predicates.

**Dynamic Operations Refactor and Extension**
* Renamed `DynamicOperations` enum to `Ops` and added new `In` and `NotIn` operations to support SQL IN/NOT IN clauses for dynamic predicates. [[1]](diffhunk://#diff-4b93fcb4642ae30ca6616a6019f993af12a7bcc223db70b833fd428bd744aafaL6-R6) [[2]](diffhunk://#diff-4b93fcb4642ae30ca6616a6019f993af12a7bcc223db70b833fd428bd744aafaL56-R72)
* Updated all references in predicate builder and extension methods to use the new `Ops` enum instead of `DynamicOperations`. [[1]](diffhunk://#diff-314ecd02144548d25e56b45291bf3f56fba1d544e776f3f578467021a1322af2L27-R38) [[2]](diffhunk://#diff-314ecd02144548d25e56b45291bf3f56fba1d544e776f3f578467021a1322af2L51-R71) [[3]](diffhunk://#diff-babe1100a649303970e92c8014c2e8032e1fb578126a2682abe4e53851453ccdL32-R56) [[4]](diffhunk://#diff-babe1100a649303970e92c8014c2e8032e1fb578126a2682abe4e53851453ccdL91-R111) [[5]](diffhunk://#diff-babe1100a649303970e92c8014c2e8032e1fb578126a2682abe4e53851453ccdL119-R139) [[6]](diffhunk://#diff-babe1100a649303970e92c8014c2e8032e1fb578126a2682abe4e53851453ccdL148-R168) [[7]](diffhunk://#diff-babe1100a649303970e92c8014c2e8032e1fb578126a2682abe4e53851453ccdL177-R197) [[8]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L31-R31) [[9]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L41-R44) [[10]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L54-R54) [[11]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L64-R65) [[12]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L75-R78)

**Predicate Building and Validation Improvements**
* Enhanced `BuildClause` to generate correct dynamic LINQ for `In` and `NotIn`, and added validation logic to ensure array values are non-empty and not strings for these operations. [[1]](diffhunk://#diff-314ecd02144548d25e56b45291bf3f56fba1d544e776f3f578467021a1322af2L51-R71) [[2]](diffhunk://#diff-314ecd02144548d25e56b45291bf3f56fba1d544e776f3f578467021a1322af2R99-R141)
* Improved enum value validation to handle both single values and arrays for `In`/`NotIn` operations.
* Added array validation in the dynamic expression builder to ensure only valid collections are used for `In`/`NotIn`.

**Testing and Miscellaneous**
* Updated unit tests to use the new `Ops` enum and verify correct operation adjustment for various property types. [[1]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L31-R31) [[2]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L41-R44) [[3]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L54-R54) [[4]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L64-R65) [[5]](diffhunk://#diff-d695009321f06492118b6f48e1cab33da677dff2d2ff920d2be46b0bb84ae8f6L75-R78)
* Added a commented-out utility for converting arrays to typed enum arrays for EF Core compatibility.

These changes make dynamic predicate building more robust and flexible, especially for scenarios requiring SQL IN/NOT IN logic and strong type validation.