### PR TITLE
up

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,7 +1,7 @@
 name: .NET
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 on:


### PR DESCRIPTION
This pull request makes a minor update to the workflow permissions in `.github/workflows/dotnet-publish.yml`, changing the `contents` permission from `read` to `write`. This adjustment allows the workflow to perform write operations on repository contents, which may be necessary for publishing or deployment tasks.