### PR TITLE
Fixed the DtoGenerator to support multi projects

### DIFF
--- a/src/DKNet.FW.sln.DotSettings.user
+++ b/src/DKNet.FW.sln.DotSettings.user
@@ -588,14 +588,14 @@
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=0109f02b_002D3fcd_002D4b82_002Db667_002Dfa31ec54c795/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="All tests from &amp;lt;AspNet&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Solution /&gt;
 &lt;/SessionState&gt;</s:String>
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=076f3db0_002D9c90_002D464c_002Da713_002Df7c36319c497/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="All tests from &amp;lt;AspNet&amp;gt;\&amp;lt;AspCore.Idempotency.Tests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=076f3db0_002D9c90_002D464c_002Da713_002Df7c36319c497/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="All tests from &amp;lt;AspNet&amp;gt;\&amp;lt;AspCore.Idempotency.Tests&amp;gt;" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Or&gt;
     &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src/AspNet/AspCore.Idempotency.Tests" Presentation="&amp;lt;AspNet&amp;gt;\&amp;lt;AspCore.Idempotency.Tests&amp;gt;" /&gt;
     &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src/AspNet/AspCore.Idempotency.MsSqlStore.Tests" Presentation="&amp;lt;AspNet&amp;gt;\&amp;lt;AspCore.Idempotency.MsSqlStore.Tests&amp;gt;" /&gt;
   &lt;/Or&gt;
 &lt;/SessionState&gt;</s:String>
 	
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd972a6a_002D73e3_002D4962_002D9e9b_002Dc5100a3f62e4/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=bd972a6a_002D73e3_002D4962_002D9e9b_002Dc5100a3f62e4/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" Name="Session" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;Or&gt;
     &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src" Presentation="&amp;lt;AspNet&amp;gt;" /&gt;
     &lt;Project Location="/Users/steven/_CODE/DRUNK/DKNet/src" Presentation="&amp;lt;Core&amp;gt;" /&gt;

--- a/src/EfCore/DKNet.EfCore.DtoGenerator/DKNet.EfCore.DtoGenerator.csproj
+++ b/src/EfCore/DKNet.EfCore.DtoGenerator/DKNet.EfCore.DtoGenerator.csproj
@@ -18,7 +18,9 @@
         <!-- Suppress warnings about netstandard2.0 -->
         <NoWarn>$(NoWarn);NU5128</NoWarn>
     </PropertyGroup>
-
+    <ItemGroup>
+        <InternalsVisibleTo Include="EfCore.DtoGenerator.Tests"/>
+    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
@@ -26,10 +28,10 @@
 
     <ItemGroup>
         <!-- Pack the generator DLL as an analyzer -->
-        <!--        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>-->
+        <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
 
         <!-- Include the attribute file in consuming projects -->
-        <!--        <None Include="GenerateDtoAttribute.cs" Pack="true" PackagePath="contentFiles/cs/any;content" BuildAction="Compile"/>-->
+        <None Include="GenerateDtoAttribute.cs" Pack="true" PackagePath="contentFiles/cs/any;content" BuildAction="Compile"/>
 
         <!-- Standard package files -->
         <None Include="..\..\NugetLogo.png" Pack="true" PackagePath="\"/>

--- a/src/EfCore/DKNet.EfCore.DtoGenerator/GenerateDtoAttribute.cs
+++ b/src/EfCore/DKNet.EfCore.DtoGenerator/GenerateDtoAttribute.cs
@@ -35,7 +35,7 @@ namespace DKNet.EfCore.DtoGenerator;
 /// are automatically excluded, including both single entity properties and collection properties.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-public sealed class GenerateDtoAttribute : Attribute
+internal sealed class GenerateDtoAttribute : Attribute
 {
     /// <summary>
     /// Gets the entity type to generate a DTO for.

--- a/src/EfCore/EfCore.DtoGenerator.Tests/EfCore.DtoGenerator.Tests.csproj
+++ b/src/EfCore/EfCore.DtoGenerator.Tests/EfCore.DtoGenerator.Tests.csproj
@@ -66,7 +66,10 @@
         <ProjectReference Include="..\DKNet.EfCore.DtoEntities\DKNet.EfCore.DtoEntities.csproj"/>
         <ProjectReference Include="..\DKNet.EfCore.DtoGenerator\DKNet.EfCore.DtoGenerator.csproj"
                           OutputItemType="Analyzer"
-                          ReferenceOutputAssembly="true"/>
+                          ReferenceOutputAssembly="true">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </ProjectReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pull request introduces a few project configuration changes to improve testability and packaging for the `EfCore.DtoGenerator` project. The most significant updates involve making the `GenerateDtoAttribute` internal, exposing internals for testing, and refining project references for test projects.

**Testability improvements:**

* Added `InternalsVisibleTo` in `DKNet.EfCore.DtoGenerator.csproj` to allow the `EfCore.DtoGenerator.Tests` project to access internal members, facilitating more thorough unit testing.
* Changed `GenerateDtoAttribute` from `public` to `internal`, restricting its visibility to within the assembly and friend assemblies.

**Test project reference configuration:**

* Updated the test project reference in `EfCore.DtoGenerator.Tests.csproj` to include `PrivateAssets` and `IncludeAssets`, ensuring proper analyzer and asset handling during test builds.

**Packaging adjustments:**

* Enabled packaging of the analyzer DLL and attribute source file in the NuGet package by uncommenting relevant `<None Include=... Pack="true" ... />` entries in `DKNet.EfCore.DtoGenerator.csproj`.

**IDE/test session state:**

* Minor changes to the `.DotSettings.user` file, updating the active state of test sessions (no impact on code or build).