### PR TITLE
up

### DIFF
--- a/src/EfCore/DKNet.EfCore.Extensions/Configurations/IDataSeedingConfiguration.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Configurations/IDataSeedingConfiguration.cs
@@ -8,7 +8,7 @@ namespace DKNet.EfCore.Extensions.Configurations;
 
 /// <summary>
 ///     Describes a data seeding configuration for an entity type. Implementations may provide a synchronous
-///     list of data via <see cref="HasData" />, and/or an asynchronous seeding callback via <see cref="SeedAsync" />.
+///     list of data asynchronous seeding callback via <see cref="SeedAsync" />.
 /// </summary>
 public interface IDataSeedingConfiguration
 {
@@ -30,13 +30,6 @@ public interface IDataSeedingConfiguration
     Func<DbContext, bool, CancellationToken, Task>? SeedAsync { get; }
 
     /// <summary>
-    ///     Model-managed seed data (collection of anonymous/dynamic objects) that will be used by EF Core's model seeding
-    ///     support.
-    ///     Implementations may expose strongly typed collections via the generic base class and map them to this property.
-    /// </summary>
-    IEnumerable<dynamic> HasData { get; }
-
-    /// <summary>
     ///     The CLR <see cref="Type" /> of the entity that this seeding configuration targets.
     /// </summary>
     Type EntityType { get; }
@@ -46,7 +39,7 @@ public interface IDataSeedingConfiguration
 
 /// <summary>
 ///     Generic base class for data seeding configurations. Implementers can provide model-managed seed data via
-///     <see cref="GetData" /> or an asynchronous seed routine via <see cref="SeedAsync" />.
+///     <see cref="GetDataAsync" /> or an asynchronous seed routine via <see cref="SeedAsync" />.
 /// </summary>
 /// <typeparam name="TEntity">The entity type to seed.</typeparam>
 public abstract class DataSeedingConfiguration<TEntity> : IDataSeedingConfiguration where TEntity : class
@@ -57,14 +50,27 @@ public abstract class DataSeedingConfiguration<TEntity> : IDataSeedingConfigurat
     public Type EntityType => typeof(TEntity);
 
     /// <inheritdoc />
-    public IEnumerable<dynamic> HasData => GetData();
-
-    /// <inheritdoc />
     public virtual int Order => 0;
 
-
     /// <inheritdoc />
-    public virtual Func<DbContext, bool, CancellationToken, Task>? SeedAsync => null;
+    public virtual Func<DbContext, bool, CancellationToken, Task> SeedAsync =>
+        async (context, isMigration, cancellation) =>
+        {
+            var data = await GetDataAsync(cancellation).ConfigureAwait(false);
+            if (data.Count == 0)
+                return;
+
+            var dbSet = context.Set<TEntity>();
+            foreach (var item in data)
+            {
+                // Check if the item already exists in the database to avoid duplicates
+                var exists = await dbSet.AnyAsync(e => e.Equals(item), cancellation).ConfigureAwait(false);
+                if (!exists)
+                    await dbSet.AddAsync(item, cancellation).ConfigureAwait(false);
+            }
+
+            await context.SaveChangesAsync(cancellation).ConfigureAwait(false);
+        };
 
     #endregion
 
@@ -74,7 +80,7 @@ public abstract class DataSeedingConfiguration<TEntity> : IDataSeedingConfigurat
     ///     Gets the collection of seed data for the target entity type./>
     /// </summary>
     /// <returns></returns>
-    protected abstract ICollection<TEntity> GetData();
+    protected abstract ValueTask<ICollection<TEntity>> GetDataAsync(CancellationToken cancellation = default);
 
     #endregion
 }

--- a/src/EfCore/DKNet.EfCore.Extensions/Extensions/EfCoreDataSeedingExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Extensions/EfCoreDataSeedingExtensions.cs
@@ -36,33 +36,6 @@ public static class EfCoreDataSeedingExtensions
     }
 
     /// <summary>
-    ///     Registers model-managed seed data from discovered <see cref="IDataSeedingConfiguration" /> types.
-    ///     This will call HasData on the model for any configuration that exposes non-empty HasData collections.
-    /// </summary>
-    /// <param name="modelBuilder">The model builder to register seed data on.</param>
-    /// <param name="assemblies">Assemblies to scan for IDataSeedingConfiguration implementations.</param>
-    internal static void RegisterDataSeeding(this ModelBuilder modelBuilder, params Assembly[] assemblies)
-    {
-        ArgumentNullException.ThrowIfNull(modelBuilder);
-
-        var seedingTypes = assemblies.GetDataSeedingTypes();
-        var instances = seedingTypes
-            .Select(t => Activator.CreateInstance(t) as IDataSeedingConfiguration)
-            .OfType<IDataSeedingConfiguration>()
-            .OrderBy(s => s.Order);
-
-        foreach (var item in instances)
-        {
-            var data = item.HasData?.ToList() ?? [];
-            if (data.Count == 0) continue;
-
-            var entityType = item.EntityType;
-            // ModelBuilder.Entity(Type).HasData accepts params object[]
-            modelBuilder.Entity(entityType).HasData(data.ToArray());
-        }
-    }
-
-    /// <summary>
     ///     Configure the <see cref="DbContextOptionsBuilder" /> to automatically run data seeding callbacks
     ///     discovered in the provided assemblies during migrations or startup.
     /// </summary>

--- a/src/EfCore/DKNet.EfCore.Extensions/Internal/AutoConfigModelCustomizer.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Internal/AutoConfigModelCustomizer.cs
@@ -14,22 +14,16 @@ internal sealed class AutoConfigModelCustomizer(ModelCustomizer original) : IMod
         var assemblies = GetAssemblies(dbContext);
 
         //Register Entities
-        foreach (var assembly in assemblies)
-        {
-            modelBuilder.ApplyConfigurationsFromAssembly(assembly);
-        }
+        foreach (var assembly in assemblies) modelBuilder.ApplyConfigurationsFromAssembly(assembly);
 
         //Register StaticData Of
-        modelBuilder.RegisterDataSeeding(assemblies);
+        //modelBuilder.RegisterDataSeeding(assemblies);
 
         //Register Global Filter
         modelBuilder.RegisterGlobalModelBuilders(assemblies, dbContext);
 
         //Register Sequence
-        if (dbContext.IsSqlServer())
-        {
-            modelBuilder.RegisterSequences(assemblies);
-        }
+        if (dbContext.IsSqlServer()) modelBuilder.RegisterSequences(assemblies);
     }
 
     public void Customize(ModelBuilder modelBuilder, DbContext context)
@@ -44,10 +38,7 @@ internal sealed class AutoConfigModelCustomizer(ModelCustomizer original) : IMod
         var register = options.FindExtension<EntityAutoConfigRegister>();
         var assemblies = register?.Assemblies ?? [];
 
-        if (assemblies.Length <= 0)
-        {
-            assemblies = [dbContext.GetType().Assembly];
-        }
+        if (assemblies.Length <= 0) assemblies = [dbContext.GetType().Assembly];
 
         return assemblies;
     }

--- a/src/EfCore/EfCore.Extensions.Tests/DataSeedingTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/DataSeedingTests.cs
@@ -8,19 +8,20 @@ public class UserSeedingConfiguration : DataSeedingConfiguration<User>
 {
     #region Methods
 
-    protected override ICollection<User> GetData() =>
-    [
-        new(
-            1, "seeded1")
-        {
-            FirstName = "Seeded", LastName = "User1"
-        },
-        new(2, "seeded2")
-        {
-            FirstName = "Seeded",
-            LastName = "User2"
-        }
-    ];
+    protected override ValueTask<ICollection<User>> GetDataAsync(CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult<ICollection<User>>(
+        [
+            new User(
+                1, "seeded1")
+            {
+                FirstName = "Seeded", LastName = "User1"
+            },
+            new User(2, "seeded2")
+            {
+                FirstName = "Seeded",
+                LastName = "User2"
+            }
+        ]);
 
     #endregion
 }


### PR DESCRIPTION
This pull request refactors the data seeding configuration system in the `DKNet.EfCore.Extensions` library to modernize and simplify how seed data is provided and applied. The main changes involve removing the synchronous, model-managed seeding interface (`HasData`), shifting to an asynchronous data seeding approach, and updating related APIs and implementations accordingly.

**Core changes to data seeding:**

* Removed the `HasData` property and related logic from the `IDataSeedingConfiguration` interface and its implementations, eliminating support for synchronous, model-managed seed data registration. [[1]](diffhunk://#diff-bfc0005c88795560da7b8472b3c2e9fe3977a512a0c1e3a43fbd7d3c23effb9bL32-L38) [[2]](diffhunk://#diff-c94f22d541282522eb6b483c2addad64822c5e31f91392a83ba6b35e9967d7feL38-L64)
* Changed the abstract method in `DataSeedingConfiguration<TEntity>` from `GetData()` (synchronous) to `GetDataAsync()` (asynchronous), and updated the `SeedAsync` implementation to use this method for seeding data asynchronously and avoiding duplicates. [[1]](diffhunk://#diff-bfc0005c88795560da7b8472b3c2e9fe3977a512a0c1e3a43fbd7d3c23effb9bL77-R83) [[2]](diffhunk://#diff-bfc0005c88795560da7b8472b3c2e9fe3977a512a0c1e3a43fbd7d3c23effb9bL60-R73)
* Updated the XML documentation throughout to reflect the new asynchronous-only seeding model. [[1]](diffhunk://#diff-bfc0005c88795560da7b8472b3c2e9fe3977a512a0c1e3a43fbd7d3c23effb9bL11-R11) [[2]](diffhunk://#diff-bfc0005c88795560da7b8472b3c2e9fe3977a512a0c1e3a43fbd7d3c23effb9bL49-R42)

**Related updates and cleanup:**

* Removed the `RegisterDataSeeding` extension and its usage from the model customization pipeline, as model-managed seeding via `HasData` is no longer supported. [[1]](diffhunk://#diff-c94f22d541282522eb6b483c2addad64822c5e31f91392a83ba6b35e9967d7feL38-L64) [[2]](diffhunk://#diff-2bfe71608b6b4e3f6c7d7de9f06dee640b0c05f51ca63a30d370ea3c1e34994bL17-R26)
* Updated test implementations to override the new `GetDataAsync` method instead of the removed `GetData`.
* Minor code style cleanups in the assembly discovery logic for consistency.