### PR TITLE
fix(deps): downgrade Mapster packages to stable 10.0.7

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -59,9 +59,9 @@
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageVersion Include="ForEvolve.FluentValidation.AspNetCore.Http" Version="1.0.26" />
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="10.0.11" />
-    <PackageVersion Include="Mapster" Version="10.0.8" />
-    <PackageVersion Include="Mapster.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Mapster.EFCore" Version="10.0.8" />
+    <PackageVersion Include="Mapster" Version="10.0.7" />
+    <PackageVersion Include="Mapster.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Mapster.EFCore" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />


### PR DESCRIPTION
## What changed
- Downgraded Mapster, Mapster.DependencyInjection, and Mapster.EFCore from 10.0.8 to 10.0.7 in `Directory.Packages.props`

## Why
Version 10.0.8 only exists as a prerelease (`10.0.8-pre06`) on NuGet, causing all CI builds to fail with NU1102.

## How to verify
```bash
dotnet restore src/DKNet.FW.sln
```
Should resolve all packages without errors.

## Out of scope
- No API changes — 10.0.7 is the previous stable release.