### PR TITLE
fix: fix PdfGenerator test failures and improve test coverage

### DIFF
--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -1,11 +1,11 @@
 name: Build, Test, Coverage & Check
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [ dev ]
   pull_request:
     branches: [ main, dev ]
-  workflow_dispatch: 
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -47,7 +47,6 @@ jobs:
         run: dotnet restore src/DKNet.FW.sln
 
       - name: Build
-        continue-on-error: true
         run: dotnet build src/DKNet.FW.sln --no-restore --configuration Release
 
       - name: Test
@@ -74,7 +73,7 @@ jobs:
           verbose: true
 
       - name: Commit SonarCloud Results
-        if: ${{ secrets.SONAR_TOKEN != '' }}
+        continue-on-error: true
         run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
       - name: Verify Coverage Report

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -5,6 +5,7 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ main, dev ]
+  workflow_dispatch: 
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -36,11 +36,11 @@ jobs:
             10.x.x
 
       - name: Install SonarCloud Tools
-        if: ${{ secrets.SONAR_TOKEN != '' }}
+        continue-on-error: true
         run: dotnet tool install --global dotnet-sonarscanner
 
       - name: Prepare SonarCloud Scan
-        if: ${{ secrets.SONAR_TOKEN != '' }}
+        continue-on-error: true
         run: dotnet sonarscanner begin /o:"baoduy2412" /k:"baoduy_DKNet" /d:sonar.cs.opencover.reportsPaths="**/coverage.*.xml" /d:sonar.scanner.scanAll=false /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.skipJreProvisioning=true
 
       - name: Restore dependencies

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/CachedResponseTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/CachedResponseTests.cs
@@ -1,0 +1,67 @@
+using DKNet.AspCore.Idempotency;
+
+namespace AspCore.Idempotency.Tests.Unit;
+
+public class CachedResponseTests
+{
+    #region Methods
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtIsInFuture_ReturnsFalse()
+    {
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        response.IsExpired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtIsInPast_ReturnsTrue()
+    {
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-2),
+            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(-1)
+        };
+        response.IsExpired.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsExpired_WhenExpiresAtIsNull_ReturnsFalse()
+    {
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = null
+        };
+        response.IsExpired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CachedResponse_CanHaveNullBody()
+    {
+        var response = new CachedResponse
+        {
+            StatusCode = 204,
+            Body = null,
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        response.Body.ShouldBeNull();
+        response.StatusCode.ShouldBe(204);
+    }
+
+    #endregion
+}

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyEndpointFilterThrowConflictTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyEndpointFilterThrowConflictTests.cs
@@ -173,5 +173,39 @@ public class IdempotencyEndpointFilterThrowConflictTests(ApiFixtureThrowConflict
         response.Headers.ShouldNotBeNull();
     }
 
+    [Fact]
+    public async Task InvokeAsync_WhenKeyIsTooLong_Returns400BadRequest()
+    {
+        // Arrange
+        var client = fixture.CreateClient();
+        var json = JsonSerializer.Serialize(new { name = "test item" });
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/items") { Content = content };
+        request.Headers.Add("X-Idempotency-Key", new string('a', 256)); // Exceeds default 255 char limit
+
+        // Act
+        var response = await client.SendAsync(request);
+
+        // Assert
+        ((int)response.StatusCode).ShouldBe((int)HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenKeyHasInvalidFormat_Returns400BadRequest()
+    {
+        // Arrange
+        var client = fixture.CreateClient();
+        var json = JsonSerializer.Serialize(new { name = "test item" });
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/items") { Content = content };
+        request.Headers.Add("X-Idempotency-Key", "invalid!@#$key"); // Contains invalid characters
+
+        // Act
+        var response = await client.SendAsync(request);
+
+        // Assert
+        ((int)response.StatusCode).ShouldBe((int)HttpStatusCode.BadRequest);
+    }
+
     #endregion
 }

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyStoreEdgeCaseTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyStoreEdgeCaseTests.cs
@@ -1,0 +1,156 @@
+using DKNet.AspCore.Idempotency;
+using DKNet.AspCore.Idempotency.Store;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace AspCore.Idempotency.Tests.Unit;
+
+/// <summary>
+///     Tests for <see cref="IdempotencyDistributedCacheStore" /> edge cases not covered
+///     by the main repository tests.
+/// </summary>
+public class IdempotencyStoreEdgeCaseTests
+{
+    #region Fields
+
+    private readonly IDistributedCache _cache;
+    private readonly ILogger<IdempotencyEndpointFilter> _logger;
+
+    #endregion
+
+    #region Constructors
+
+    public IdempotencyStoreEdgeCaseTests()
+    {
+        _cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        _logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<IdempotencyEndpointFilter>();
+    }
+
+    #endregion
+
+    #region Methods
+
+    private IdempotencyDistributedCacheStore CreateStore(IdempotencyOptions? options = null) =>
+        new(_cache, Options.Create(options ?? new IdempotencyOptions()), _logger);
+
+    private static IdempotentKeyInfo MakeKey(string key) =>
+        new() { IdempotentKey = key, Endpoint = "/api/test", Method = "POST" };
+
+    [Fact]
+    public async Task IsKeyProcessedAsync_WhenResponseIsAlreadyExpired_ReturnsFalseAndRemovesFromCache()
+    {
+        // Arrange: Store an already-expired response
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"id\": 1}",
+            ContentType = "application/json",
+            CreatedAt = now.AddHours(-2),
+            ExpiresAt = now.AddSeconds(-1) // already expired
+        };
+
+        var key = Guid.NewGuid().ToString();
+        await store.MarkKeyAsProcessedAsync(MakeKey(key), response);
+
+        // Act
+        var result = await store.IsKeyProcessedAsync(MakeKey(key));
+
+        // Assert
+        result.processed.ShouldBeFalse();
+        result.response.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task IsKeyProcessedAsync_WhenResponseHasNoExpiration_NeverExpires()
+    {
+        // Arrange: Store a response with null ExpiresAt
+        var store = CreateStore();
+        var now = DateTimeOffset.UtcNow;
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"id\": 1}",
+            ContentType = "application/json",
+            CreatedAt = now,
+            ExpiresAt = null
+        };
+
+        var key = Guid.NewGuid().ToString();
+        await store.MarkKeyAsProcessedAsync(MakeKey(key), response);
+
+        // Act
+        var result = await store.IsKeyProcessedAsync(MakeKey(key));
+
+        // Assert
+        result.processed.ShouldBeTrue();
+        result.response.ShouldNotBeNull();
+        result.response!.ExpiresAt.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task MarkKeyAsProcessedAsync_DifferentEndpoints_StoredSeparately()
+    {
+        // Arrange: Same idempotency key but different endpoints
+        var store = CreateStore();
+        var idempotencyKey = Guid.NewGuid().ToString();
+
+        var keyInfo1 = new IdempotentKeyInfo { IdempotentKey = idempotencyKey, Endpoint = "/api/orders", Method = "POST" };
+        var keyInfo2 = new IdempotentKeyInfo { IdempotentKey = idempotencyKey, Endpoint = "/api/items", Method = "POST" };
+
+        var response1 = new CachedResponse
+        {
+            StatusCode = 201, Body = "{\"type\":\"order\"}", ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        var response2 = new CachedResponse
+        {
+            StatusCode = 201, Body = "{\"type\":\"item\"}", ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act
+        await store.MarkKeyAsProcessedAsync(keyInfo1, response1);
+        await store.MarkKeyAsProcessedAsync(keyInfo2, response2);
+
+        var result1 = await store.IsKeyProcessedAsync(keyInfo1);
+        var result2 = await store.IsKeyProcessedAsync(keyInfo2);
+
+        // Assert: Both keys stored independently
+        result1.processed.ShouldBeTrue();
+        result2.processed.ShouldBeTrue();
+        result1.response!.Body.ShouldBe("{\"type\":\"order\"}");
+        result2.response!.Body.ShouldBe("{\"type\":\"item\"}");
+    }
+
+    [Fact]
+    public async Task MarkKeyAsProcessedAsync_DifferentMethods_StoredSeparately()
+    {
+        // Arrange: Same endpoint and key but different HTTP methods
+        var store = CreateStore();
+        var idempotencyKey = Guid.NewGuid().ToString();
+
+        var postKey = new IdempotentKeyInfo { IdempotentKey = idempotencyKey, Endpoint = "/api/orders", Method = "POST" };
+        var putKey = new IdempotentKeyInfo { IdempotentKey = idempotencyKey, Endpoint = "/api/orders", Method = "PUT" };
+
+        var response = new CachedResponse
+        {
+            StatusCode = 200, Body = "{}", ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow, ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act
+        await store.MarkKeyAsProcessedAsync(postKey, response);
+
+        var postResult = await store.IsKeyProcessedAsync(postKey);
+        var putResult = await store.IsKeyProcessedAsync(putKey);
+
+        // Assert: POST key found, PUT key not found
+        postResult.processed.ShouldBeTrue();
+        putResult.processed.ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotentKeyInfoTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotentKeyInfoTests.cs
@@ -1,0 +1,97 @@
+using DKNet.AspCore.Idempotency;
+
+namespace AspCore.Idempotency.Tests.Unit;
+
+public class IdempotentKeyInfoTests
+{
+    #region Fields
+
+    private static IdempotencyOptions DefaultOptions => new();
+
+    #endregion
+
+    #region Methods
+
+    [Fact]
+    public void CompositeKey_CombinesMethodEndpointAndKey()
+    {
+        var info = new IdempotentKeyInfo { IdempotentKey = "test-key", Endpoint = "/api/orders", Method = "POST" };
+        info.CompositeKey.ShouldBe("POST:/api/orders:test-key");
+    }
+
+    [Fact]
+    public void CompositeKey_WhenKeyIsNull_UsesEmptyString()
+    {
+        var info = new IdempotentKeyInfo { IdempotentKey = null, Endpoint = "/api/orders", Method = "GET" };
+        info.CompositeKey.ShouldBe("GET:/api/orders:");
+    }
+
+    [Fact]
+    public void IsValid_WhenKeyHasInvalidChars_ReturnsFailed()
+    {
+        var info = new IdempotentKeyInfo
+            { IdempotentKey = "invalid!@#$key", Endpoint = "/api/test", Method = "POST" };
+        var result = info.IsValid(DefaultOptions);
+        result.IsFailed.ShouldBeTrue();
+        result.Errors[0].Message.ShouldContain("format is invalid");
+    }
+
+    [Fact]
+    public void IsValid_WhenKeyIsEmpty_ReturnsFailed()
+    {
+        var info = new IdempotentKeyInfo { IdempotentKey = "", Endpoint = "/api/test", Method = "POST" };
+        var result = info.IsValid(DefaultOptions);
+        result.IsFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValid_WhenKeyIsNull_ReturnsFailed()
+    {
+        var info = new IdempotentKeyInfo { IdempotentKey = null, Endpoint = "/api/test", Method = "POST" };
+        var result = info.IsValid(DefaultOptions);
+        result.IsFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValid_WhenKeyIsTooLong_ReturnsFailed()
+    {
+        var options = new IdempotencyOptions { MaxIdempotencyKeyLength = 10 };
+        var info = new IdempotentKeyInfo
+            { IdempotentKey = "12345678901", Endpoint = "/api/test", Method = "POST" };
+        var result = info.IsValid(options);
+        result.IsFailed.ShouldBeTrue();
+        result.Errors[0].Message.ShouldContain("must not exceed");
+    }
+
+    [Fact]
+    public void IsValid_WhenKeyIsValid_ReturnsOk()
+    {
+        var info = new IdempotentKeyInfo
+            { IdempotentKey = "valid-key-123_ABC", Endpoint = "/api/test", Method = "POST" };
+        var result = info.IsValid(DefaultOptions);
+        result.IsFailed.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsValid_WhenKeyIsWhitespace_ReturnsFailed()
+    {
+        var info = new IdempotentKeyInfo { IdempotentKey = "   ", Endpoint = "/api/test", Method = "POST" };
+        var result = info.IsValid(DefaultOptions);
+        result.IsFailed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsValid_WhenKeyMatchesDefaultPattern_ReturnsOk()
+    {
+        var info = new IdempotentKeyInfo
+        {
+            IdempotentKey = Guid.NewGuid().ToString(), // UUID format: uses hyphens and alphanumeric
+            Endpoint = "/api/test",
+            Method = "POST"
+        };
+        var result = info.IsValid(DefaultOptions);
+        result.IsFailed.ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/src/EfCore/DKNet.EfCore.DataAuthorization/DKNet.EfCore.DataAuthorization.csproj
+++ b/src/EfCore/DKNet.EfCore.DataAuthorization/DKNet.EfCore.DataAuthorization.csproj
@@ -8,6 +8,10 @@
         <None Include="README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
     <ItemGroup>
+        <InternalsVisibleTo Include="EfCore.DataAuthorization.Tests"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\DKNet.EfCore.Extensions\DKNet.EfCore.Extensions.csproj"/>
         <ProjectReference Include="..\DKNet.EfCore.Hooks\DKNet.EfCore.Hooks.csproj"/>
     </ItemGroup>

--- a/src/EfCore/EfCore.DataAuthorization.Tests/AdditionalFixtures.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/AdditionalFixtures.cs
@@ -1,0 +1,89 @@
+using DKNet.EfCore.Hooks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace EfCore.DataAuthorization.Tests;
+
+public sealed class EmptyOwnerKeyFixture : IAsyncLifetime
+{
+    #region Fields
+
+    private SqliteConnection? _connection;
+
+    #endregion
+
+    #region Properties
+
+    public ServiceProvider Provider { get; private set; } = null!;
+
+    #endregion
+
+    #region Methods
+
+    public async Task DisposeAsync()
+    {
+        if (_connection != null) await _connection.DisposeAsync();
+        await Provider.DisposeAsync();
+    }
+
+    public async Task InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        Provider = new ServiceCollection()
+            .AddLogging()
+            .AddDataOwnerProvider<DddContext, EmptyOwnerKeyProvider>()
+            .AddDbContextWithHook<DddContext>(builder =>
+                builder.UseSqlite(_connection)
+                    .UseAutoConfigModel())
+            .BuildServiceProvider();
+
+        var db = Provider.GetRequiredService<DddContext>();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    #endregion
+}
+
+public sealed class EmptyAccessibleKeysFixture : IAsyncLifetime
+{
+    #region Fields
+
+    private SqliteConnection? _connection;
+
+    #endregion
+
+    #region Properties
+
+    public ServiceProvider Provider { get; private set; } = null!;
+
+    #endregion
+
+    #region Methods
+
+    public async Task DisposeAsync()
+    {
+        if (_connection != null) await _connection.DisposeAsync();
+        await Provider.DisposeAsync();
+    }
+
+    public async Task InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        Provider = new ServiceCollection()
+            .AddLogging()
+            .AddDataOwnerProvider<DddContext, EmptyAccessibleKeysProvider>()
+            .AddDbContextWithHook<DddContext>(builder =>
+                builder.UseSqlite(_connection)
+                    .UseAutoConfigModel())
+            .BuildServiceProvider();
+
+        var db = Provider.GetRequiredService<DddContext>();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
@@ -1,0 +1,125 @@
+using DKNet.EfCore.DataAuthorization.Internals;
+using Microsoft.EntityFrameworkCore;
+
+namespace EfCore.DataAuthorization.Tests;
+
+/// <summary>
+///     Tests covering edge cases: empty ownership key and empty accessible keys.
+/// </summary>
+public class DataAuthorizationEdgeCaseTests
+{
+    #region Methods
+
+    /// <summary>
+    ///     Verifies that <see cref="DataAuthExtensions.GetQueryFilterKey{TEntity}" /> produces the expected key.
+    /// </summary>
+    [Fact]
+    public void DataAuthExtensions_GetQueryFilterKey_ReturnsExpectedKey()
+    {
+        var key = DataAuthExtensions.GetQueryFilterKey<Root>();
+        key.ShouldContain(typeof(Root).FullName!);
+        key.ShouldContain(nameof(DataOwnerAuthQuery));
+    }
+
+    #endregion
+}
+
+/// <summary>
+///     Tests for the scenario where the ownership key is empty (e.g., unauthenticated or system context).
+///     The <see cref="DKNet.EfCore.DataAuthorization.Internals.DataOwnerHook" /> should skip ownership assignment.
+/// </summary>
+public class DataAuthorizationEmptyOwnerKeyTests(EmptyOwnerKeyFixture fixture)
+    : IClassFixture<EmptyOwnerKeyFixture>
+{
+    #region Methods
+
+    [Fact]
+    public async Task WhenOwnerKeyIsEmpty_EntitiesRetainOriginalOwnedBy()
+    {
+        // Arrange: EmptyOwnerKeyProvider returns "" for GetOwnershipKey()
+        // The hook should return early and NOT set OwnedBy on the entity
+        var db = fixture.Provider.GetRequiredService<DddContext>();
+        var entity = new Root("Test with no owner key", "original-owner");
+
+        // Act
+        await db.AddAsync(entity);
+        await db.SaveChangesAsync();
+
+        // Assert: OwnedBy was NOT overwritten since the key was empty and entity already had a value
+        var ownedBy = ((IOwnedBy)entity).OwnedBy;
+        ownedBy.ShouldBe("original-owner");
+    }
+
+    [Fact]
+    public async Task WhenOwnerKeyIsEmpty_EntityWithEmptyOwnedBy_RemainsEmpty()
+    {
+        // Arrange: Provider returns empty ownerKey; entity has empty OwnedBy
+        // Hook fires but ownerKey is empty → returns early → entity OwnedBy stays empty/default
+        var db = fixture.Provider.GetRequiredService<DddContext>();
+
+        // Use an entity that has OwnedBy set already so we can still add to DB
+        // (the query filter is based on AccessibleKeys which is ["Steven"])
+        var entity = new Root("Test with empty owner, owned by Steven", "Steven");
+
+        // Act
+        await db.AddAsync(entity);
+        await db.SaveChangesAsync();
+
+        // Assert: entity is visible via query filter (AccessibleKeys = ["Steven"])
+        var result = await db.Set<Root>().ToListAsync();
+        result.ShouldNotBeEmpty();
+    }
+
+    #endregion
+}
+
+/// <summary>
+///     Tests for the scenario where AccessibleKeys is empty, meaning all entities should be visible
+///     (super-user / admin context).
+/// </summary>
+public class DataAuthorizationEmptyAccessibleKeysTests(EmptyAccessibleKeysFixture fixture)
+    : IClassFixture<EmptyAccessibleKeysFixture>
+{
+    #region Methods
+
+    [Fact]
+    public async Task WhenAccessibleKeysIsEmpty_AllEntitiesAreVisible()
+    {
+        // Arrange: EmptyAccessibleKeysProvider returns [] for GetAccessibleKeys()
+        // The query filter's !AccessibleKeys.Any() == true branch is exercised → show ALL entities
+        var db = fixture.Provider.GetRequiredService<DddContext>();
+
+        var entity1 = new Root("Entity owned by Steven", "Steven");
+        var entity2 = new Root("Entity owned by other", "other-user");
+        var entity3 = new Root("Entity owned by admin", "admin");
+
+        await db.AddRangeAsync(entity1, entity2, entity3);
+        await db.SaveChangesAsync();
+
+        // Act: With empty AccessibleKeys, the query filter allows ALL entities
+        var allEntities = await db.Set<Root>().ToListAsync();
+
+        // Assert: Entities with ANY OwnedBy value should be visible
+        allEntities.Count.ShouldBeGreaterThanOrEqualTo(3);
+        allEntities.ShouldContain(e => ((IOwnedBy)e).OwnedBy == "Steven");
+        allEntities.ShouldContain(e => ((IOwnedBy)e).OwnedBy == "other-user");
+        allEntities.ShouldContain(e => ((IOwnedBy)e).OwnedBy == "admin");
+    }
+
+    [Fact]
+    public void WhenAccessibleKeysIsEmpty_AccessibleKeysCollectionIsEmpty()
+    {
+        var db = fixture.Provider.GetRequiredService<DddContext>();
+        db.AccessibleKeys.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WhenOwnershipKeyIsSetAndAccessibleKeysEmpty_ProviderReturnsCorrectKey()
+    {
+        var provider = fixture.Provider.GetRequiredService<IDataOwnerProvider>();
+        provider.GetOwnershipKey().ShouldBe("Steven");
+        provider.GetAccessibleKeys().ShouldBeEmpty();
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/AdditionalProviders.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/AdditionalProviders.cs
@@ -1,0 +1,26 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace EfCore.DataAuthorization.Tests.TestEntities;
+
+/// <summary>
+///     A data owner provider that returns an empty ownership key, simulating an unauthenticated or
+///     system-level context where ownership is not assigned.
+/// </summary>
+internal class EmptyOwnerKeyProvider : IDataOwnerProvider
+{
+    public ICollection<string> GetAccessibleKeys() => ["Steven"];
+
+    public string GetOwnershipKey() => string.Empty;
+}
+
+/// <summary>
+///     A data owner provider with no accessible keys, simulating a super-user context where
+///     all entities should be visible regardless of ownership.
+/// </summary>
+internal class EmptyAccessibleKeysProvider : IDataOwnerProvider
+{
+    public ICollection<string> GetAccessibleKeys() => [];
+
+    public string GetOwnershipKey() => "Steven";
+}

--- a/src/Services/Svc.PdfGenerators.Tests/ChromeDownloadFixture.cs
+++ b/src/Services/Svc.PdfGenerators.Tests/ChromeDownloadFixture.cs
@@ -1,0 +1,24 @@
+using PuppeteerSharp;
+
+namespace Svc.PdfGenerators.Tests;
+
+/// <summary>
+///     Collection definition that ensures Chrome is downloaded once before any PDF generation tests run.
+///     Tests in this collection run sequentially to avoid concurrent Chrome download race conditions.
+/// </summary>
+[CollectionDefinition("PdfGeneratorChrome")]
+public class PdfGeneratorChromeCollection : ICollectionFixture<ChromeDownloadFixture>;
+
+/// <summary>
+///     Fixture that downloads Chrome (via PuppeteerSharp) once for all PDF generation tests.
+///     By sharing this fixture across a collection, the download happens exactly once.
+/// </summary>
+public class ChromeDownloadFixture : IAsyncLifetime
+{
+    public async Task InitializeAsync()
+    {
+        await new BrowserFetcher().DownloadAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/src/Services/Svc.PdfGenerators.Tests/PdfGeneratorTests.cs
+++ b/src/Services/Svc.PdfGenerators.Tests/PdfGeneratorTests.cs
@@ -3,6 +3,7 @@ using Xunit.Abstractions;
 
 namespace Svc.PdfGenerators.Tests;
 
+[Collection("PdfGeneratorChrome")]
 public class PdfGeneratorTests(ITestOutputHelper testOutputHelper)
 {
     #region Methods


### PR DESCRIPTION
## Summary

Fixed all 3 failing PdfGenerator tests and added new tests to improve coverage across three projects.

## Changes

### DKNet.Svc. Fixed 3 failing testsPdfGenerators 
**Root cause:** `ConvertHtmlAsync`, `ConvertMarkdownFileAsync`, and `ConvertMultipleMarkdownFilesAsync` tests were racing to download Chrome concurrently, causing a file-lock IOException.

**Fix:** Added `ChromeDownloadFixture` (pre-downloads Chrome once via PuppeteerSharp) and `[Collection("PdfGeneratorChrome")]` to serialize PDF generation tests.

**Result:** 175/175 passing (was 172/175)

### DKNet.AspCore. Improved coverageIdempotency 
New tests added (54 total, was 35):
- ` covers IsValid() for null/empty/whitespace keys, key too long, invalid formatIdempotentKeyInfoTests` 
- ` covers IsExpired for null ExpiresAt, future, and past expiryCachedResponseTests` 
- ` covers expired response removal, separate keys per endpoint/methodIdempotencyStoreEdgeCaseTests` 
- Integration tests for key-too-long and invalid-format requests returning 400

### DKNet.EfCore. Improved coverageDataAuthorization 
New tests added (20 total, was 14):
- ` covers DataAuthExtensions.GetQueryFilterKeyDataAuthorizationEdgeCaseTests` 
- ` exercises DataOwnerHook early-return branchDataAuthorizationEmptyOwnerKeyTests` 
- ` exercises empty accessibility keys filter branchDataAuthorizationEmptyAccessibleKeysTests` 
