### PR TITLE
test: improve coverage for PR #294 gap files

### DIFF
--- a/src/EfCore/EfCore.Extensions.Tests/DataSeedingEdgeCaseTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/DataSeedingEdgeCaseTests.cs
@@ -1,0 +1,123 @@
+// <copyright file="DataSeedingEdgeCaseTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+using DKNet.EfCore.Extensions.Configurations;
+
+namespace EfCore.Extensions.Tests;
+
+/// <summary>
+///     Covers the early-return branches in <see cref="DataSeedingConfiguration{TEntity}.SeedAsync" />
+///     that the happy-path <see cref="DataSeedingTests" /> does not exercise:
+///     (1) seed data collection is empty, (2) all entities already exist in the database.
+/// </summary>
+public class DataSeedingEdgeCaseTests
+{
+    #region Empty-data branch
+
+    private sealed class EmptyUserSeedingConfiguration : DataSeedingConfiguration<User>
+    {
+        protected override ValueTask<ICollection<User>> GetDataAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<ICollection<User>>([]);
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenGetDataReturnsEmpty_DoesNothing()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<MyDbContext>()
+            .UseInMemoryDatabase("DataSeedingEdge_Empty_" + Guid.NewGuid())
+            .Options;
+        await using var context = new MyDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        var config = new EmptyUserSeedingConfiguration();
+
+        // Act: invoke SeedAsync directly (matches the runtime contract used by UseAutoDataSeeding)
+        await config.SeedAsync(context, false, CancellationToken.None);
+
+        // Assert: empty seed must not add any rows
+        (await context.Set<User>().CountAsync()).ShouldBe(0);
+    }
+
+    #endregion
+
+    #region All-exist branch
+
+    // Custom entity with value equality so the production code's HashSet<TEntity> with
+    // EqualityComparer<TEntity>.Default treats AsNoTracking-loaded copies as the same as the
+    // seed candidates and the early-return at "toAdd.Count == 0" fires.
+    private sealed class ColorRow
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+
+        public override bool Equals(object? obj) => obj is ColorRow other && other.Id == Id;
+        public override int GetHashCode() => Id.GetHashCode();
+    }
+
+    private sealed class ColorDbContext(DbContextOptions<ColorDbContext> options) : DbContext(options)
+    {
+        public DbSet<ColorRow> Colors => Set<ColorRow>();
+    }
+
+    private sealed class FixedColorSeedingConfiguration : DataSeedingConfiguration<ColorRow>
+    {
+        public static IReadOnlyList<ColorRow> Rows { get; set; } = [];
+
+        protected override ValueTask<ICollection<ColorRow>> GetDataAsync(CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<ICollection<ColorRow>>(Rows.ToList());
+    }
+
+    [Fact]
+    public async Task SeedAsync_WhenAllEntitiesAlreadyExist_SkipsAddRange()
+    {
+        // Arrange
+        var dbName = "DataSeedingEdge_AllExist_" + Guid.NewGuid();
+        var options = new DbContextOptionsBuilder<ColorDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+
+        var seedRows = new[]
+        {
+            new ColorRow { Id = 101, Name = "Red" },
+            new ColorRow { Id = 102, Name = "Blue" }
+        };
+
+        // Pre-populate with rows that compare-equal to the seed candidates.
+        await using (var seedContext = new ColorDbContext(options))
+        {
+            await seedContext.Database.EnsureCreatedAsync();
+            seedContext.AddRange(seedRows.Select(r => new ColorRow { Id = r.Id, Name = r.Name }));
+            await seedContext.SaveChangesAsync();
+        }
+
+        await using var context = new ColorDbContext(options);
+        FixedColorSeedingConfiguration.Rows = seedRows;
+        var config = new FixedColorSeedingConfiguration();
+
+        // Act — invoking SeedAsync should NOT insert any duplicates because every candidate is
+        // already in the existing set, hitting the `toAdd.Count == 0` early-return.
+        await config.SeedAsync(context, false, CancellationToken.None);
+
+        // Assert
+        (await context.Set<ColorRow>().CountAsync()).ShouldBe(2);
+    }
+
+    #endregion
+
+    #region Properties
+
+    [Fact]
+    public void Defaults_OrderIsZeroAndEntityTypeMatchesGenericArgument()
+    {
+        IDataSeedingConfiguration config = new EmptyUserSeedingConfiguration();
+
+        config.Order.ShouldBe(0);
+        config.EntityType.ShouldBe(typeof(User));
+        config.SeedAsync.ShouldNotBeNull();
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateBuilderEdgeCaseTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateBuilderEdgeCaseTests.cs
@@ -1,0 +1,135 @@
+// <copyright file="DynamicPredicateBuilderEdgeCaseTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+using DKNet.EfCore.Specifications.Dynamics;
+
+namespace EfCore.Specifications.Tests;
+
+/// <summary>
+///     Edge-case tests for the internal helpers in <see cref="DynamicPredicateBuilderExtensions" />.
+///     These tests exercise the security/validation branches that the higher-level
+///     <c>DynamicAnd</c>/<c>DynamicOr</c> tests do not hit directly: null/empty/oversized property
+///     names, expressions containing dangerous patterns, and <c>ValidateArrayValue</c> rejections.
+/// </summary>
+public class DynamicPredicateBuilderEdgeCaseTests
+{
+    #region IsValidPropertyName
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void IsValidPropertyName_NullOrWhitespace_ReturnsFalse(string? input)
+        => DynamicPredicateBuilderExtensions.IsValidPropertyName(input).ShouldBeFalse();
+
+    [Fact]
+    public void IsValidPropertyName_ExceedsMaxLength_ReturnsFalse()
+    {
+        // 257 chars triggers the > 256 guard
+        var oversized = new string('A', 257);
+        DynamicPredicateBuilderExtensions.IsValidPropertyName(oversized).ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData("Name; DROP TABLE")] // semicolon
+    [InlineData("Name OR 1=1")]      // spaces and equals
+    [InlineData("Name()")]            // parentheses
+    [InlineData("Name[0]")]           // brackets
+    [InlineData("Name+Other")]        // plus
+    public void IsValidPropertyName_DangerousCharacters_ReturnsFalse(string input)
+        => DynamicPredicateBuilderExtensions.IsValidPropertyName(input).ShouldBeFalse();
+
+    [Theory]
+    [InlineData("Name")]
+    [InlineData("Category.Name")]
+    [InlineData("snake_case")]
+    [InlineData("kebab-case")] // hyphens are allowed pre-normalization (ToPascalCase strips them)
+    public void IsValidPropertyName_ValidPaths_ReturnsTrue(string input)
+        => DynamicPredicateBuilderExtensions.IsValidPropertyName(input).ShouldBeTrue();
+
+    #endregion
+
+    #region ValidateExpression
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateExpression_NullOrWhitespace_Throws(string? input)
+        => Should.Throw<ArgumentException>(() => DynamicPredicateBuilderExtensions.ValidateExpression(input!));
+
+    [Theory]
+    [InlineData("System.IO.File.Delete(\"/etc/passwd\")")]
+    [InlineData("typeof(Object).GetMethods()")]
+    [InlineData("Activator.CreateInstance(typeof(object))")]
+    [InlineData("Environment.Exit(0)")]
+    [InlineData("Process.Start(\"cmd\")")]
+    [InlineData("Assembly.Load(\"evil\")")]
+    [InlineData("Task.Run(() => 1)")]
+    [InlineData("AppDomain.CurrentDomain")]
+    [InlineData("Marshal.Copy(IntPtr.Zero, null, 0, 0)")]
+    public void ValidateExpression_DangerousPattern_Throws(string expression)
+    {
+        var ex = Should.Throw<ArgumentException>(
+            () => DynamicPredicateBuilderExtensions.ValidateExpression(expression));
+        ex.Message.ShouldContain("disallowed pattern");
+        ex.ParamName.ShouldBe("expression");
+    }
+
+    [Theory]
+    [InlineData("Name == @0")]
+    [InlineData("Price > @0 AND IsActive")]
+    [InlineData("Category.Name.Contains(@0)")]
+    public void ValidateExpression_SafeExpression_DoesNotThrow(string expression)
+        => Should.NotThrow(() => DynamicPredicateBuilderExtensions.ValidateExpression(expression));
+
+    #endregion
+
+    #region ValidateArrayValue
+
+    [Theory]
+    [InlineData(Ops.In)]
+    [InlineData(Ops.NotIn)]
+    public void ValidateArrayValue_NullValue_ReturnsFalse(Ops op)
+        => DynamicPredicateBuilderExtensions.ValidateArrayValue(null, op).ShouldBeFalse();
+
+    [Theory]
+    [InlineData(Ops.In)]
+    [InlineData(Ops.NotIn)]
+    public void ValidateArrayValue_StringValue_ReturnsFalse(Ops op)
+        => DynamicPredicateBuilderExtensions.ValidateArrayValue("a string", op).ShouldBeFalse();
+
+    [Theory]
+    [InlineData(Ops.In)]
+    [InlineData(Ops.NotIn)]
+    public void ValidateArrayValue_NonEnumerableValue_ReturnsFalse(Ops op)
+        => DynamicPredicateBuilderExtensions.ValidateArrayValue(42, op).ShouldBeFalse();
+
+    [Theory]
+    [InlineData(Ops.In)]
+    [InlineData(Ops.NotIn)]
+    public void ValidateArrayValue_EmptyCollection_ReturnsFalse(Ops op)
+        => DynamicPredicateBuilderExtensions.ValidateArrayValue(Array.Empty<int>(), op).ShouldBeFalse();
+
+    [Theory]
+    [InlineData(Ops.In)]
+    [InlineData(Ops.NotIn)]
+    public void ValidateArrayValue_NonEmptyCollection_ReturnsTrue(Ops op)
+        => DynamicPredicateBuilderExtensions.ValidateArrayValue(new[] { 1, 2 }, op).ShouldBeTrue();
+
+    [Theory]
+    [InlineData(Ops.Equal)]
+    [InlineData(Ops.GreaterThan)]
+    [InlineData(Ops.Contains)]
+    public void ValidateArrayValue_NonInOperations_AlwaysReturnsTrue(Ops op)
+    {
+        DynamicPredicateBuilderExtensions.ValidateArrayValue(null, op).ShouldBeTrue();
+        DynamicPredicateBuilderExtensions.ValidateArrayValue("anything", op).ShouldBeTrue();
+        DynamicPredicateBuilderExtensions.ValidateArrayValue(Array.Empty<int>(), op).ShouldBeTrue();
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateExpressionOverloadTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateExpressionOverloadTests.cs
@@ -1,0 +1,173 @@
+// <copyright file="DynamicPredicateExpressionOverloadTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+using DKNet.EfCore.Specifications.Dynamics;
+
+namespace EfCore.Specifications.Tests;
+
+/// <summary>
+///     Covers the four overloads of <see cref="DynamicPredicateExtensions" /> that operate on
+///     <see cref="Expression{TDelegate}" /> (rather than LinqKit's <see cref="ExpressionStarter{T}" />)
+///     plus the raw dynamic-LINQ string overloads on both predicate kinds. These paths were not
+///     exercised by the existing test suite, so the branches in <c>BuildDynamicExpression</c> and the
+///     <c>ValidateExpression</c> + parse pipeline ran without coverage.
+/// </summary>
+public class DynamicPredicateExpressionOverloadTests(TestDbFixture fixture) : IClassFixture<TestDbFixture>
+{
+    #region Fields
+
+    private readonly TestDbContext _context = fixture.Db!;
+
+    #endregion
+
+    #region Expression<Func<T,bool>> property-name overloads
+
+    [Fact]
+    public void DynamicAnd_OnExpressionFunc_WithValidProperty_CombinesWithAnd()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        var combined = baseExpr.DynamicAnd("Price", Ops.GreaterThan, 100m);
+
+        // sanity check: predicate is usable in EF query
+        var sql = _context.Products.AsExpandable().Where(combined).ToQueryString();
+        sql.ShouldContain("IsActive");
+        sql.ShouldContain("Price");
+    }
+
+    [Fact]
+    public void DynamicAnd_OnExpressionFunc_WithInvalidPropertyName_ReturnsOriginalPredicate()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        var combined = baseExpr.DynamicAnd("does.not.exist", Ops.Equal, "x");
+
+        // identical instance — the BuildDynamicExpression returned null, so the original is returned unchanged
+        combined.ShouldBeSameAs(baseExpr);
+    }
+
+    [Fact]
+    public void DynamicAnd_OnExpressionFunc_WithDangerousPropertyName_ReturnsOriginalPredicate()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        // semicolon will fail IsValidPropertyName → BuildDynamicExpression returns null
+        var combined = baseExpr.DynamicAnd("Name; DROP TABLE", Ops.Equal, "x");
+
+        combined.ShouldBeSameAs(baseExpr);
+    }
+
+    [Fact]
+    public void DynamicOr_OnExpressionFunc_WithValidProperty_CombinesWithOr()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        var combined = baseExpr.DynamicOr("Price", Ops.LessThan, 50m);
+
+        var sql = _context.Products.AsExpandable().Where(combined).ToQueryString();
+        sql.ShouldContain("IsActive");
+        sql.ShouldContain("Price");
+    }
+
+    [Fact]
+    public void DynamicOr_OnExpressionFunc_WithInvalidPropertyName_ReturnsOriginalPredicate()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        var combined = baseExpr.DynamicOr("nope", Ops.Equal, "x");
+
+        combined.ShouldBeSameAs(baseExpr);
+    }
+
+    #endregion
+
+    #region Expression<Func<T,bool>> raw expression overloads
+
+    [Fact]
+    public void DynamicAnd_OnExpressionFunc_WithRawExpression_ParsesAndAndsCorrectly()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        var combined = baseExpr.DynamicAnd("Price > @0", 100m);
+
+        var sql = _context.Products.AsExpandable().Where(combined).ToQueryString();
+        sql.ShouldContain("Price");
+        sql.ShouldContain("IsActive");
+    }
+
+    [Fact]
+    public void DynamicOr_OnExpressionFunc_WithRawExpression_ParsesAndOrsCorrectly()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        var combined = baseExpr.DynamicOr("Price < @0", 50m);
+
+        var sql = _context.Products.AsExpandable().Where(combined).ToQueryString();
+        sql.ShouldContain("Price");
+        sql.ShouldContain("IsActive");
+    }
+
+    [Fact]
+    public void DynamicAnd_OnExpressionFunc_WithDangerousRawExpression_Throws()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        Should.Throw<ArgumentException>(() => baseExpr.DynamicAnd("System.IO.File.Delete(@0)", new object?[] { "x" }));
+    }
+
+    [Fact]
+    public void DynamicOr_OnExpressionFunc_WithDangerousRawExpression_Throws()
+    {
+        Expression<Func<Product, bool>> baseExpr = p => p.IsActive;
+
+        Should.Throw<ArgumentException>(() => baseExpr.DynamicOr("typeof(Object).ToString()", new object?[] { "x" }));
+    }
+
+    #endregion
+
+    #region ExpressionStarter<T> raw expression overloads
+
+    [Fact]
+    public void DynamicAnd_OnExpressionStarter_WithRawExpression_ParsesAndAndsCorrectly()
+    {
+        var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+        var combined = predicate.DynamicAnd("Price > @0", 100m);
+
+        var sql = _context.Products.AsExpandable().Where(combined).ToQueryString();
+        sql.ShouldContain("Price");
+        sql.ShouldContain("IsActive");
+    }
+
+    [Fact]
+    public void DynamicOr_OnExpressionStarter_WithRawExpression_ParsesAndOrsCorrectly()
+    {
+        var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+        var combined = predicate.DynamicOr("Price < @0", 50m);
+
+        var sql = _context.Products.AsExpandable().Where(combined).ToQueryString();
+        sql.ShouldContain("Price");
+        sql.ShouldContain("IsActive");
+    }
+
+    [Fact]
+    public void DynamicAnd_OnExpressionStarter_WithDangerousRawExpression_Throws()
+    {
+        var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+        Should.Throw<ArgumentException>(() => predicate.DynamicAnd("Activator.CreateInstance(@0)", new object?[] { "x" }));
+    }
+
+    [Fact]
+    public void DynamicOr_OnExpressionStarter_WithDangerousRawExpression_Throws()
+    {
+        var predicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+        Should.Throw<ArgumentException>(() => predicate.DynamicOr("Process.Start(@0)", new object?[] { "x" }));
+    }
+
+    #endregion
+}

--- a/src/Services/Svc.BlobStorage.Tests/LocalBlobServiceEdgeCaseTests.cs
+++ b/src/Services/Svc.BlobStorage.Tests/LocalBlobServiceEdgeCaseTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="LocalBlobServiceEdgeCaseTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+using DKNet.Svc.BlobStorage.Local;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Svc.BlobStorage.Tests;
+
+/// <summary>
+///     Edge-case tests for <see cref="LocalBlobService" /> that exercise the security-sensitive
+///     and defensive branches not covered by the happy-path <c>LocalBlobStorageTest</c>:
+///     null <c>RootFolder</c> fallback, path-traversal protection, leading-slash normalization,
+///     and cancellation-token early-exits for file/directory deletion.
+/// </summary>
+public class LocalBlobServiceEdgeCaseTests : IDisposable
+{
+    #region Fields
+
+    private readonly string _root;
+    private readonly LocalBlobService _service;
+
+    #endregion
+
+    #region Constructors
+
+    public LocalBlobServiceEdgeCaseTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "DKNet-LocalBlobEdge-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+
+        var options = Options.Create(new LocalDirectoryOptions { RootFolder = _root });
+        _service = new LocalBlobService(options, NullLogger<LocalBlobService>.Instance);
+    }
+
+    #endregion
+
+    #region Methods
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, true);
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void Constructor_NullRootFolder_FallsBackToCurrentDirectoryLocalStore()
+    {
+        // Arrange: options with RootFolder = null should fall back to "{cwd}/LocalStore"
+        var options = Options.Create(new LocalDirectoryOptions { RootFolder = null });
+
+        // Act
+        var service = new LocalBlobService(options, NullLogger<LocalBlobService>.Instance);
+
+        // Assert: not throwing during construction is the contract; usage should resolve relative
+        // to current directory + LocalStore. We verify behavior indirectly via path traversal guard.
+        Should.Throw<UnauthorizedAccessException>(() =>
+            service.CheckExistsAsync(new BlobRequest("../../../etc/passwd") { Type = BlobTypes.File })
+                .GetAwaiter().GetResult());
+    }
+
+    [Fact]
+    public async Task CheckExistsAsync_PathTraversal_ThrowsUnauthorizedAccess()
+    {
+        var attempt = new BlobRequest("../../../etc/passwd") { Type = BlobTypes.File };
+
+        var ex = await Should.ThrowAsync<UnauthorizedAccessException>(
+            async () => await _service.CheckExistsAsync(attempt));
+        ex.Message.ShouldContain("outside the configured root directory");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_PathTraversal_ThrowsUnauthorizedAccess()
+    {
+        var attempt = new BlobRequest("../escape.txt") { Type = BlobTypes.File };
+
+        await Should.ThrowAsync<UnauthorizedAccessException>(
+            async () => await _service.DeleteAsync(attempt));
+    }
+
+    [Fact]
+    public async Task CheckExistsAsync_LeadingSlash_TreatedAsRelative()
+    {
+        // Arrange: write a file directly under root, then look it up with a leading slash.
+        await File.WriteAllTextAsync(Path.Combine(_root, "lead.txt"), "x");
+
+        var blob = new BlobRequest("/lead.txt") { Type = BlobTypes.File };
+
+        // Act
+        var exists = await _service.CheckExistsAsync(blob);
+
+        // Assert: leading slash must be stripped, resolving to <root>/lead.txt
+        exists.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_FileWithCancelledToken_ReturnsFalseAndKeepsFile()
+    {
+        var path = Path.Combine(_root, "keep.txt");
+        await File.WriteAllTextAsync(path, "x");
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var result = await _service.DeleteAsync(
+            new BlobRequest("keep.txt") { Type = BlobTypes.File },
+            cts.Token);
+
+        result.ShouldBeFalse();
+        File.Exists(path).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_FolderWithCancelledToken_ReturnsFalseAndKeepsFolder()
+    {
+        var folder = Path.Combine(_root, "keep-folder");
+        Directory.CreateDirectory(folder);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var result = await _service.DeleteAsync(
+            new BlobRequest("keep-folder") { Type = BlobTypes.Directory },
+            cts.Token);
+
+        result.ShouldBeFalse();
+        Directory.Exists(folder).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task SaveAsync_NestedPath_CreatesMissingDirectories()
+    {
+        var fileName = "nested/deep/created.txt";
+        var blob = new BlobDetails.BlobData(fileName, new BinaryData("hi"u8.ToArray()))
+        {
+            Overwrite = false,
+            Type = BlobTypes.File
+        };
+
+        var saved = await _service.SaveAsync(blob);
+
+        saved.ShouldBe(fileName);
+        File.Exists(Path.Combine(_root, "nested", "deep", "created.txt")).ShouldBeTrue();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Adds 65 unit tests targeting the lowest-coverage files in the [codecov report for PR #294](https://app.codecov.io/gh/baoduy/DKNet/pull/294). Closes the patch-coverage gap by exercising security validation branches, expression overloads, blob-service defensive paths, and data-seeding early-returns.

## Coverage targets

| File | Before | Gap addressed |
|------|--------|---------------|
| `DynamicPredicateExtensions.cs` | 50.0% | Expression<Func<T,bool>> property-name + raw-expression overloads (none were tested) |
| `DynamicPredicateBuilderExtensions.cs` | 83.5% | `IsValidPropertyName` null/empty/oversized/bad-char branches, `ValidateExpression` null + every dangerous pattern, `ValidateArrayValue` non-enumerable rejection |
| `LocalBlobService.cs` | 86.2% | Null `RootFolder` fallback, path-traversal `UnauthorizedAccessException`, leading-slash normalization, cancellation-token early-exit (file + folder), nested-path SaveAsync |
| `IDataSeedingConfiguration.cs` | 81.0% | Empty seed-data early-return, all-rows-already-exist early-return, default `Order`/`EntityType` properties |

Not addressed:
- `TaskSetups.cs` (10% reported) — the file uses C# 14 `extension` members which the coverage instrumentation does not appear to track. The methods are already exercised by `BackgroundJobTests`.
- `IdempotencySqlServerStore.IsExpired` branch — structurally unreachable because the EF query already filters `ExpiresAt > DateTime.UtcNow`; this is defensive code.

## New test files

- `DynamicPredicateBuilderEdgeCaseTests.cs` (29 cases)
- `DynamicPredicateExpressionOverloadTests.cs` (12 cases)
- `LocalBlobServiceEdgeCaseTests.cs` (7 cases)
- `DataSeedingEdgeCaseTests.cs` (3 cases)

All new tests pass; full `EfCore.Specifications.Tests` (301), `EfCore.Extensions.Tests` (85), and `Svc.BlobStorage.Tests` Local-fixture suite (17) remain green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>