### PR TITLE
chore(deps): weekly NuGet update + fix High-severity transitive vulnerabilities

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -41,36 +41,36 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Asp.Versioning.Http" Version="8.1.0" />
-    <PackageVersion Include="Aspire.Hosting" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.2" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.5.0" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="9.5.2" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.5.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageVersion Include="AutoBogus" Version="2.13.1" />
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.5" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.22.1" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.9.6" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.25.2" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentResults" Version="4.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageVersion Include="ForEvolve.FluentValidation.AspNetCore.Http" Version="1.0.26" />
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="10.0.11" />
-    <PackageVersion Include="Mapster" Version="10.0.7" />
-    <PackageVersion Include="Mapster.DependencyInjection" Version="10.0.7" />
-    <PackageVersion Include="Mapster.EFCore" Version="10.0.7" />
+    <PackageVersion Include="Mapster" Version="10.0.8" />
+    <PackageVersion Include="Mapster.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Mapster.EFCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
@@ -79,47 +79,50 @@
     <PackageVersion Include="Microsoft.Net.Compilers.Toolset" Version="5.3.0" />
     <PackageVersion Include="System.Composition" Version="10.0.8" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.4.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageVersion Include="OpenTelemetry" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.13.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.13.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.9.0" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="SharpGrip.FluentValidation.AutoValidation.Endpoints" Version="1.5.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <!-- Override vulnerable transitive: EF Core Sqlite pulls SQLitePCLRaw 2.1.11 (GHSA-2m69-gcr7-jv3q, High).
+         3.0.x is the fixed line; referenced directly by the Sqlite-backed test projects. -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="SlimMessageBus" Version="3.0.0" />
     <PackageVersion Include="SlimMessageBus.Host" Version="3.4.0" />
     <PackageVersion Include="SlimMessageBus.Host.AzureServiceBus" Version="3.3.4" />
@@ -128,24 +131,24 @@
     <PackageVersion Include="SlimMessageBus.Host.Memory" Version="3.4.0" />
     <PackageVersion Include="SlimMessageBus.Host.Serialization.SystemTextJson" Version="3.4.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
-    <PackageVersion Include="System.Memory.Data" Version="10.0.8" />
-    <PackageVersion Include="Testcontainers.Azurite" Version="4.11.0" />
+    <PackageVersion Include="System.Memory.Data" Version="10.0.9" />
+    <PackageVersion Include="Testcontainers.Azurite" Version="4.12.0" />
     <PackageVersion Include="TestContainers.Container.Database.MsSql" Version="1.5.4" />
-    <PackageVersion Include="Testcontainers.Minio" Version="4.11.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageVersion Include="Testcontainers.Minio" Version="4.12.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.8.0" />
     <PackageVersion Include="X.PagedList.EF" Version="10.5.9" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Markdig" Version="1.1.3" />
+    <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="PdfPig" Version="0.1.14" />
-    <PackageVersion Include="PuppeteerSharp" Version="24.40.0" />
-    <PackageVersion Include="YamlDotNet" Version="17.1.0" />
+    <PackageVersion Include="PuppeteerSharp" Version="25.1.2" />
+    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.58">
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.108">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
@@ -153,7 +156,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.203">
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>

--- a/src/EfCore/EfCore.AuditLogs.Tests/EfCore.AuditLogs.Tests.csproj
+++ b/src/EfCore/EfCore.AuditLogs.Tests/EfCore.AuditLogs.Tests.csproj
@@ -24,6 +24,8 @@
         <PackageReference Include="xunit"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <!-- Force fixed SQLitePCLRaw (EF Sqlite pulls vulnerable 2.1.11, GHSA-2m69-gcr7-jv3q) -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Shouldly"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
     </ItemGroup>

--- a/src/EfCore/EfCore.DataAuthorization.Tests/EfCore.DataAuthorization.Tests.csproj
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/EfCore.DataAuthorization.Tests.csproj
@@ -17,6 +17,8 @@
     <ItemGroup>
         <PackageReference Include="Bogus"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <!-- Force fixed SQLitePCLRaw (EF Sqlite pulls vulnerable 2.1.11, GHSA-2m69-gcr7-jv3q) -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Shouldly"/>
         <PackageReference Include="xunit"/>

--- a/src/EfCore/EfCore.Events.Tests/EfCore.Events.Tests.csproj
+++ b/src/EfCore/EfCore.Events.Tests/EfCore.Events.Tests.csproj
@@ -17,6 +17,8 @@
         <PackageReference Include="Mapster.DependencyInjection"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <!-- Force fixed SQLitePCLRaw (EF Sqlite pulls vulnerable 2.1.11, GHSA-2m69-gcr7-jv3q) -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Shouldly"/>
         <PackageReference Include="xunit"/>

--- a/src/EfCore/EfCore.Extensions.Tests/EfCore.Extensions.Tests.csproj
+++ b/src/EfCore/EfCore.Extensions.Tests/EfCore.Extensions.Tests.csproj
@@ -21,6 +21,8 @@
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <!-- Force fixed SQLitePCLRaw (EF Sqlite pulls vulnerable 2.1.11, GHSA-2m69-gcr7-jv3q) -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug"/>

--- a/src/EfCore/EfCore.HookTests/EfCore.HookTests.csproj
+++ b/src/EfCore/EfCore.HookTests/EfCore.HookTests.csproj
@@ -18,6 +18,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <!-- Force fixed SQLitePCLRaw (EF Sqlite pulls vulnerable 2.1.11, GHSA-2m69-gcr7-jv3q) -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Shouldly"/>
         <PackageReference Include="xunit"/>
         <PackageReference Include="xunit.runner.visualstudio">

--- a/src/EfCore/EfCore.Repos.Tests/EfCore.Repos.Tests.csproj
+++ b/src/EfCore/EfCore.Repos.Tests/EfCore.Repos.Tests.csproj
@@ -18,6 +18,8 @@
         <PackageReference Include="Mapster"/>
         <PackageReference Include="Mapster.EFCore"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+        <!-- Force fixed SQLitePCLRaw (EF Sqlite pulls vulnerable 2.1.11, GHSA-2m69-gcr7-jv3q) -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="coverlet.collector">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EfCore/EfCore.Specifications.Tests/EfCore.Specifications.Tests.csproj
+++ b/src/EfCore/EfCore.Specifications.Tests/EfCore.Specifications.Tests.csproj
@@ -20,6 +20,8 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+        <!-- Force fixed SQLitePCLRaw (EF Sqlite pulls vulnerable 2.1.11, GHSA-2m69-gcr7-jv3q) -->
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" />
         <PackageReference Include="Bogus" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />


### PR DESCRIPTION
## Weekly NuGet maintenance (2026-06-21)

Bumps all outdated packages to their latest stable versions and resolves two **High**-severity transitive vulnerabilities flagged by `NuGetAudit` (which were failing `dotnet restore` under `TreatWarningsAsErrors`).

### Security fixes
| Package | Advisory | Fix |
|---|---|---|
| `MessagePack` 2.5.192 (transitive) | [GHSA-hv8m-jj95-wg3x](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) (High) | Cleared by bumping `Aspire.Hosting` → 13.4.6 (pulls fixed `StreamJsonRpc`/`MessagePack`) |
| `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (transitive, via EF Core Sqlite) | [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (High) | Overridden to fixed 3.0.x via a direct `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 reference in the 7 Sqlite-backed test projects |
| `OpenTelemetry*` 1.13.1 | NU1902 (Moderate, several) | Bumped to 1.16.0 / 1.15.x |

### Notable version bumps
- **EF Core + `Microsoft.Extensions.*`**: 10.0.8 → 10.0.9
- **Aspire.Hosting / Aspire.Hosting.SqlServer**: 13.2.4 → 13.4.6 (requires OpenTelemetry 1.16.0 and `System.IdentityModel.Tokens.Jwt` 8.19.1, both bumped)
- **OpenTelemetry**: 1.13.1 → 1.16.0 (core), instrumentation → 1.15.x
- Major bumps: **PuppeteerSharp** 24 → 25, **YamlDotNet** 17 → 18
- Also: AWSSDK, Azure.Storage.Blobs, Mapster, Testcontainers 4.11 → 4.12, Microsoft.NET.Test.Sdk, coverlet, Meziantou.Analyzer, Microsoft.CodeAnalysis.NetAnalyzers, Markdig

### Why the test-project edits
EF Core Sqlite hard-pulls the vulnerable `SQLitePCLRaw` 2.1.11. With central package management, a direct `PackageReference` to `SQLitePCLRaw.bundle_e_sqlite3` (version pinned to 3.0.3 in `Directory.Packages.props`) is the targeted way to force the fixed native library only where Sqlite is used. (Solution-wide transitive pinning was tried first but caused broad downgrade conflicts — rejected as too invasive.)

### Verification
- ✅ `dotnet restore` — **0 audit findings**, no `NU1109`/`NU1605`/`NU1902` conflicts
- ✅ `dotnet build DKNet.FW.sln -c Debug` — **0 warnings, 0 errors** (warnings-as-errors enabled)
- ✅ `dotnet list package --vulnerable --include-transitive` — **no vulnerable packages**
- Pre-existing failures on `dev` (verified by running the affected projects on a clean baseline) are **unchanged** by this PR: `AspCore.Tasks` reflection bug (`_added` field `int` vs test setting `bool`), flaky Hook/AuditLog parallel-isolation tests, and the Idempotency connection-string assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
