### PR TITLE
refactor: weekly code-quality pass — 5 fixes (correctness, perf, safety)

### DIFF
--- a/src/Core/DKNet.Fw.Extensions/AsyncEnumerableExtensions.cs
+++ b/src/Core/DKNet.Fw.Extensions/AsyncEnumerableExtensions.cs
@@ -24,6 +24,8 @@ public static class AsyncEnumerableExtensions
     /// </returns>
     public static async Task<IList<T>> ToListAsync<T>(this IAsyncEnumerable<T> enumerable)
     {
+        ArgumentNullException.ThrowIfNull(enumerable);
+
         var list = new List<T>();
         await foreach (var item in enumerable)
         {

--- a/src/EfCore/DKNet.EfCore.DataAuthorization/Internals/DataOwnerHook.cs
+++ b/src/EfCore/DKNet.EfCore.DataAuthorization/Internals/DataOwnerHook.cs
@@ -55,7 +55,7 @@ internal sealed class DataOwnerHook(IDataOwnerProvider dataOwnerProvider) : IBef
             if (entity is IAuditedProperties au && string.IsNullOrEmpty(au.CreatedBy))
             {
                 au.SetPropertyValue(nameof(au.CreatedBy), ownerKey);
-                au.SetPropertyValue(nameof(au.CreatedOn), DateTimeOffset.Now);
+                au.SetPropertyValue(nameof(au.CreatedOn), DateTimeOffset.UtcNow);
             }
 
             if (entity is IOwnedBy own && string.IsNullOrEmpty(own.OwnedBy))

--- a/src/EfCore/DKNet.EfCore.Extensions/Extensions/EfCoreExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Extensions/EfCoreExtensions.cs
@@ -180,7 +180,8 @@ public static class EfCoreExtensions
             if (string.IsNullOrEmpty(att.FormatString)) return $"{value}";
 
             var f = att.FormatString.Replace(nameof(DateTime), "0", StringComparison.OrdinalIgnoreCase);
-            return string.Format(CultureInfo.CurrentCulture, f, DateTime.Now, value);
+            // Use UTC so generated sequence codes are deterministic regardless of server time zone.
+            return string.Format(CultureInfo.CurrentCulture, f, DateTime.UtcNow, value);
         }
     }
 }

--- a/src/Services/DKNet.Svc.BlobStorage.Abstractions/IBlobService.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.Abstractions/IBlobService.cs
@@ -210,7 +210,7 @@ public abstract class BlobService(BlobServiceOptions options) : IBlobService
 
         if (_options.MaxFileSizeInMb > 0)
         {
-            var fileLength = item.Data.ToArray().LongLength;
+            var fileLength = item.Data.ToMemory().Length; // Length without copying the whole payload
             var limitLength = _options.MaxFileSizeInMb * 1000000; //Convert Mb to Byte
             if (fileLength > limitLength) throw new FileLoadException("File size is invalid.");
         }

--- a/src/Services/DKNet.Svc.BlobStorage.AwsS3/S3BlobService.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.AwsS3/S3BlobService.cs
@@ -120,11 +120,18 @@ public sealed class S3BlobService(IOptions<S3Options> options, ILogger<S3BlobSer
 
             if (info?.S3Objects is null || info.S3Objects.Count == 0) break;
 
-            foreach (var obj in info.S3Objects)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                await client.DeleteObjectAsync(obj.BucketName, obj.Key, cancellationToken);
-            }
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Delete the whole page in a single request. A ListObjectsV2 page holds at most
+            // 1000 keys, which is exactly the S3 batch-delete limit, so one call per page suffices
+            // instead of one round-trip per object.
+            await client.DeleteObjectsAsync(
+                new DeleteObjectsRequest
+                {
+                    BucketName = _options.BucketName,
+                    Objects = info.S3Objects.Select(o => new KeyVersion { Key = o.Key }).ToList()
+                },
+                cancellationToken);
         } while (true);
 
         await client.DeleteObjectAsync(_options.BucketName, folderLocation, cancellationToken);


### PR DESCRIPTION
## Weekly code-quality pass (2026-06-21)

Five targeted, high-confidence improvements found while reviewing the codebase. Each is internal (no public signature changes — nothing binary-breaking) and verified by build + tests.

| # | Area | Type | Change |
|---|---|---|---|
| 1 | `DKNet.EfCore.DataAuthorization` — `DataOwnerHook` | **Correctness** | `CreatedOn` was stamped with `DateTimeOffset.Now` (local time). Switched to `UtcNow` to match `AuditedEntity` and keep audit timestamps timezone-independent. |
| 2 | `DKNet.EfCore.Extensions` — `NextSeqValueWithFormat` | **Correctness** | Date token in generated sequence codes used `DateTime.Now`. Switched to `UtcNow` so codes are deterministic regardless of server time zone. |
| 3 | `DKNet.Svc.BlobStorage.AwsS3` — `DeleteFolderAsync` | **Performance** | Deleted objects one HTTP round-trip at a time. Now batches each `ListObjectsV2` page (≤1000 keys, exactly the S3 limit) into a single `DeleteObjectsAsync` call. |
| 4 | `DKNet.Svc.BlobStorage.Abstractions` — `ValidateFile` | **Performance** | `BinaryData.ToArray()` copied the **entire** upload just to read its length. Now uses `ToMemory().Length` (no copy). |
| 5 | `DKNet.Fw.Extensions` — `AsyncEnumerableExtensions.ToListAsync` | **Safety** | Added `ArgumentNullException.ThrowIfNull` so a null argument fails with a clear exception at the trust boundary instead of an opaque NRE. |

### Verification
- ✅ `dotnet build DKNet.FW.sln -c Debug` — **0 warnings, 0 errors** (warnings-as-errors + mandatory XML docs)
- ✅ Tests pass for every touched area: `Fw.Extensions` (149), `EfCore.DataAuthorization` (20), `EfCore.Extensions` (85), `Svc.BlobStorage` (102)

> Note: this branch targets `dev`, which currently fails `NuGetAudit` on a High-severity transitive (`SQLitePCLRaw`). That is fixed independently in the weekly-deps PR (#301); merge that first (or this branch will show the audit failure until then). It is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
