### PR TITLE
chore(deps): weekly NuGet update to latest stable (2026-06-29)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -49,19 +49,19 @@
     <PackageVersion Include="Aspire.Hosting.Testing" Version="9.5.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageVersion Include="AutoBogus" Version="2.13.1" />
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.9.6" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.25.2" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.9.7" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.25.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentResults" Version="4.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageVersion Include="ForEvolve.FluentValidation.AspNetCore.Http" Version="1.0.26" />
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="10.0.11" />
-    <PackageVersion Include="Mapster" Version="10.0.8" />
-    <PackageVersion Include="Mapster.DependencyInjection" Version="10.0.8" />
-    <PackageVersion Include="Mapster.EFCore" Version="10.0.8" />
+    <PackageVersion Include="Mapster" Version="10.0.9" />
+    <PackageVersion Include="Mapster.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Mapster.EFCore" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
@@ -106,7 +106,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
@@ -143,12 +143,12 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
-    <PackageVersion Include="PdfPig" Version="0.1.14" />
+    <PackageVersion Include="PdfPig" Version="0.1.15" />
     <PackageVersion Include="PuppeteerSharp" Version="25.1.2" />
-    <PackageVersion Include="YamlDotNet" Version="18.0.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.108">
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.117">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>


### PR DESCRIPTION
## Weekly NuGet maintenance (2026-06-29)

Bumps all outdated packages to their latest **stable** versions via central package management (`src/Directory.Packages.props`).

| Package | From | To |
|---|---|---|
| AWSSDK.Core | 4.0.9.6 | 4.0.9.7 |
| AWSSDK.S3 | 4.0.25.2 | 4.0.25.3 |
| Azure.Storage.Blobs | 12.29.0 | 12.29.1 |
| Mapster | 10.0.8 | 10.0.9 |
| Mapster.DependencyInjection | 10.0.8 | 10.0.9 |
| Mapster.EFCore | 10.0.8 | 10.0.9 |
| Meziantou.Analyzer | 3.0.108 | 3.0.117 |
| Microsoft.NET.Test.Sdk | 18.6.0 | 18.7.0 |
| PdfPig | 0.1.14 | 0.1.15 |
| YamlDotNet | 18.0.0 | 18.1.0 |

### Verification
- `dotnet build DKNet.FW.sln -c Debug` → **0 warnings, 0 errors** (`TreatWarningsAsErrors=true`), incl. the bumped Meziantou analyzer.
- `dotnet list package --outdated` → none remaining.
- `dotnet list package --vulnerable --include-transitive` → none.
- Test suite green except MsSql TestContainers integration tests, which segfault because the SQL Server amd64 image runs under QEMU on the ARM CI host (environment limitation, unrelated to these bumps).

### Note
- Dependabot alert #17 (MessagePack, high) flags the `Aspire.Hosting.ServiceBus` manifest, but the package already **resolves to 2.5.302** (first patched: 2.5.301), so no pin is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
