### PR TITLE
refactor: weekly code-quality pass — 5 fixes (2026-06-29)

### DIFF
--- a/src/EfCore/DKNet.EfCore.AuditLogs/Internals/EfCoreAuditHook.cs
+++ b/src/EfCore/DKNet.EfCore.AuditLogs/Internals/EfCoreAuditHook.cs
@@ -28,7 +28,7 @@ internal sealed class EfCoreAuditHook(
         if (logs is not { Count: > 0 }) return;
 
         _cache.Remove(context.DbContext.ContextId.InstanceId);
-        PublishLogsAsync(context.DbContext, logs);
+        PublishLogs(context.DbContext, logs);
     }
 
     public override Task BeforeSaveAsync(SnapshotContext context, CancellationToken cancellationToken = default)
@@ -51,20 +51,23 @@ internal sealed class EfCoreAuditHook(
         return base.BeforeSaveAsync(context, cancellationToken);
     }
 
-    private void PublishLogsAsync(DbContext context, IEnumerable<AuditLogEntry> logs)
+    private void PublishLogs(DbContext context, IEnumerable<AuditLogEntry> logs)
     {
         // Fire & forget: do not await publishers. Each publisher runs independently.
         var publishers = serviceProvider.GetKeyedServices<IAuditLogPublisher>(context.GetType().FullName).ToList();
         foreach (var publisher in publishers)
-            Task.Run(async () =>
+            // Explicitly discard the task: this is fire-and-forget, so the returned task is never awaited.
+            _ = Task.Run(async () =>
             {
                 try
                 {
                     // Ignore cancellation for fire-and-forget to ensure attempt
                     await publisher.PublishAsync(logs, CancellationToken.None);
                 }
-                catch (DbUpdateException ex)
+                catch (Exception ex)
                 {
+                    // Catch every exception: an unobserved exception escaping a fire-and-forget Task
+                    // would otherwise surface on the finalizer thread and can tear down the process.
                     if (logger.IsEnabled(LogLevel.Error))
                         logger.LogError(ex, "Audit log publishing failed for {Publisher}", publisher.GetType().Name);
                 }

--- a/src/EfCore/DKNet.EfCore.Repos/RepoSpecExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Repos/RepoSpecExtensions.cs
@@ -85,11 +85,13 @@ public static class RepoExtensions
         /// <param name="specification">The specification to apply</param>
         /// <param name="pageNumber">Page number</param>
         /// <param name="pageSize">Page size</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A paged list of entities</returns>
         public Task<IPagedList<TEntity>> SpecsToPageListAsync(ISpecification<TEntity> specification,
             int pageNumber,
-            int pageSize) =>
+            int pageSize,
+            CancellationToken cancellationToken = default) =>
             repo.QuerySpecs(specification)
-                .ToPagedListAsync(pageNumber, pageSize);
+                .ToPagedListAsync(pageNumber, pageSize, totalSetCount: null, cancellationToken: cancellationToken);
     }
 }

--- a/src/EfCore/DKNet.EfCore.Specifications/Extensions/ModelSpecRepoExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Extensions/ModelSpecRepoExtensions.cs
@@ -59,7 +59,7 @@ public static class ModelSpecRepoExtensions
         /// <param name="cancellationToken">A token allowing the operation to be cancelled.</param>
         /// <returns>An <see cref="IList{T}" /> containing zero or more projected models.</returns>
         /// <remarks>
-        ///     Use <see cref="ToPagedListAsync{TEntity,TModel}(IRepositorySpec,IModelSpecification{TEntity,TModel},int,int)" />
+        ///     Use <see cref="ToPagedListAsync{TEntity,TModel}(IRepositorySpec,IModelSpecification{TEntity,TModel},int,int,CancellationToken)" />
         ///     for large result sets to avoid retrieving the full collection in a single query.
         /// </remarks>
         public async Task<IList<TModel>> ToListAsync<TEntity, TModel>(
@@ -77,16 +77,19 @@ public static class ModelSpecRepoExtensions
         /// <param name="specification">The model specification defining filter and ordering logic.</param>
         /// <param name="pageNumber">The 1-based page number to retrieve.</param>
         /// <param name="pageSize">The number of items per page.</param>
+        /// <param name="cancellationToken">Cancellation token for the async operation.</param>
         /// <returns>An <see cref="IPagedList{TModel}" /> representing the requested page (may be empty).</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     Thrown when <paramref name="pageNumber" /> or
         ///     <paramref name="pageSize" /> are invalid (&lt;= 0).
         /// </exception>
         public Task<IPagedList<TModel>> ToPagedListAsync<TEntity, TModel>(
-            IModelSpecification<TEntity, TModel> specification, int pageNumber, int pageSize)
+            IModelSpecification<TEntity, TModel> specification, int pageNumber, int pageSize,
+            CancellationToken cancellationToken = default)
             where TEntity : class
             where TModel : class =>
-            repo.Query<TEntity, TModel>(specification).ToPagedListAsync(pageNumber, pageSize);
+            repo.Query<TEntity, TModel>(specification)
+                .ToPagedListAsync(pageNumber, pageSize, totalSetCount: null, cancellationToken: cancellationToken);
 
         /// <summary>
         ///     Returns an async enumerable that streams the projected models for entities matching the specification using

--- a/src/EfCore/DKNet.EfCore.Specifications/Extensions/SpecRepoExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Extensions/SpecRepoExtensions.cs
@@ -115,10 +115,14 @@ public static class SpecRepoExtensions
         /// <param name="specification">The specification to apply</param>
         /// <param name="pageNumber">Page number (1-based)</param>
         /// <param name="pageSize">Number of items per page</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A task representing the asynchronous operation that returns a paged list of entities</returns>
         public Task<IPagedList<TEntity>> ToPagedListAsync<TEntity>(ISpecification<TEntity> specification,
             int pageNumber,
-            int pageSize) where TEntity : class => repo.Query(specification).ToPagedListAsync(pageNumber, pageSize);
+            int pageSize,
+            CancellationToken cancellationToken = default) where TEntity : class =>
+            repo.Query(specification)
+                .ToPagedListAsync(pageNumber, pageSize, totalSetCount: null, cancellationToken: cancellationToken);
 
         /// <summary>
         ///     Asynchronously returns a paged list of projected models matching the specification.
@@ -128,13 +132,16 @@ public static class SpecRepoExtensions
         /// <param name="specification">The specification to apply</param>
         /// <param name="pageNumber">Page number (1-based)</param>
         /// <param name="pageSize">Number of items per page</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A task representing the asynchronous operation that returns a paged list of projected models</returns>
         public Task<IPagedList<TModel>> ToPagedListAsync<TEntity, TModel>(ISpecification<TEntity> specification,
             int pageNumber,
-            int pageSize)
+            int pageSize,
+            CancellationToken cancellationToken = default)
             where TEntity : class
             where TModel : class
-            => repo.Query<TEntity, TModel>(specification).ToPagedListAsync(pageNumber, pageSize);
+            => repo.Query<TEntity, TModel>(specification)
+                .ToPagedListAsync(pageNumber, pageSize, totalSetCount: null, cancellationToken: cancellationToken);
 
         /// <summary>
         ///     Returns an async enumerable of entities matching the specification, paged.

--- a/src/EfCore/DKNet.EfCore.Specifications/PageAsyncEnumerator.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/PageAsyncEnumerator.cs
@@ -97,10 +97,19 @@ internal sealed class EfCorePageAsyncEnumerator<TEntity> : IAsyncEnumerable<TEnt
 /// </summary>
 internal static class PageAsyncEnumeratorExtensions
 {
+    #region Fields
+
+    /// <summary>
+    ///     Default number of rows fetched per database round-trip when no explicit page size is supplied.
+    /// </summary>
+    internal const int DefaultPageSize = 100;
+
+    #endregion
+
     #region Methods
 
     public static IAsyncEnumerable<TEntity> ToPageEnumerable<TEntity>(
-        this IQueryable<TEntity> query, int pageSize = 100) where TEntity : class
+        this IQueryable<TEntity> query, int pageSize = DefaultPageSize) where TEntity : class
         => new EfCorePageAsyncEnumerator<TEntity>(query, pageSize);
 
     #endregion

--- a/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageBlobService.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageBlobService.cs
@@ -16,6 +16,11 @@ public sealed class AzureStorageBlobService(IOptions<AzureStorageOptions> option
 {
     #region Fields
 
+    /// <summary>
+    ///     Lifetime applied to a generated SAS URL when the caller does not specify an explicit expiry.
+    /// </summary>
+    private static readonly TimeSpan DefaultSasLifetime = TimeSpan.FromDays(1);
+
     private readonly AzureStorageOptions _options =
         options.Value ?? throw new ArgumentNullException(nameof(options));
 
@@ -176,13 +181,13 @@ public sealed class AzureStorageBlobService(IOptions<AzureStorageOptions> option
             throw new NotSupportedException(
                 $"Current Container '{_options.ContainerName}' does not support Shared Public Access Url");
 
-        // Create a SAS token that's valid for one day
+        // Create a read-only SAS token, valid for the requested window (defaults to DefaultSasLifetime).
         var sasBuilder = new BlobSasBuilder
         {
             BlobContainerName = client.Name,
             Resource = "b",
             StartsOn = DateTimeOffset.UtcNow,
-            ExpiresOn = DateTimeOffset.UtcNow.Add(expiresFromNow ?? TimeSpan.FromDays(1)) //Blob only accessible
+            ExpiresOn = DateTimeOffset.UtcNow.Add(expiresFromNow ?? DefaultSasLifetime)
         };
 
         sasBuilder.SetPermissions(BlobContainerSasPermissions.Read);

--- a/src/Services/DKNet.Svc.Transformation/TokenExtractors/TokenResolver.cs
+++ b/src/Services/DKNet.Svc.Transformation/TokenExtractors/TokenResolver.cs
@@ -71,7 +71,10 @@ internal sealed class TokenResolver : ITokenResolver
 
     public Task<object?> ResolveAsync(IToken token, params object?[] data)
     {
-        return Task.Run(() => Resolve(token, data));
+        // Resolve is synchronous, CPU-bound reflection work. Offloading it to the thread pool with
+        // Task.Run inside a library wastes a thread and adds a context switch with no benefit; return the
+        // completed result directly and let the caller decide whether to offload.
+        return Task.FromResult(Resolve(token, data));
     }
 
     private static object? TryGetValueFromCollection(IEnumerable<object?> collection, string keyName)


### PR DESCRIPTION
## Weekly code-quality pass (2026-06-29)

Five targeted improvements found by reviewing the library source. Each is low-risk and behaviour-preserving on the success path. Categories: correctness/robustness, cancellation propagation, perf, and magic-number cleanup.

### 1. Harden fire-and-forget audit publishing — `EfCoreAuditHook`
The background `Task.Run` that runs audit publishers only caught `DbUpdateException`. Any other publisher failure escaped as an **unobserved task exception**, which can surface on the finalizer thread and tear down the process. Now catches `Exception` and logs it, explicitly discards the fire-and-forget task (`_ =`), and renames the `void` `PublishLogsAsync` → `PublishLogs` (it returns no awaitable).

### 2. Propagate `CancellationToken` through paging APIs
`SpecRepoExtensions.ToPagedListAsync` (both overloads), `ModelSpecRepoExtensions.ToPagedListAsync`, and `RepoExtensions.SpecsToPageListAsync` took no token, so a paged query could not be cancelled mid-flight. Added an optional `CancellationToken` and flowed it into `X.PagedList.EF.ToPagedListAsync`.

### 3. Name the default page size — `PageAsyncEnumeratorExtensions`
`ToPageEnumerable(..., int pageSize = 100)` → `DefaultPageSize` constant.

### 4. Name the default SAS lifetime — `AzureStorageBlobService`
Hardcoded `TimeSpan.FromDays(1)` for the default SAS expiry → `DefaultSasLifetime` field, with a clearer comment.

### 5. Drop gratuitous `Task.Run` — `TokenResolver.ResolveAsync`
`Resolve` is synchronous, CPU-bound reflection. Wrapping it in `Task.Run` inside a library wastes a thread-pool thread and adds a context switch for no benefit. Returns `Task.FromResult(...)` and lets the caller decide whether to offload. (`ITokenExtractor.ExtractAsync` was intentionally left as-is — it is fanned out via `Task.WhenAll`, where the offload provides real parallelism.)

### Verification
- `dotnet build DKNet.FW.sln -c Debug` → **0 warnings, 0 errors** (`TreatWarningsAsErrors=true`).
- Tests passing: Transform (44/44), Fw.Extensions (149/149), Repos paging (2/2), Specifications paging (31/31).
- MsSql TestContainers integration tests are skipped/failing only because the SQL Server amd64 image segfaults under QEMU on the ARM host (environment limitation). One AuditLogs fire-and-forget timing test is flaky under parallel execution **on `dev` too** (verified by reverting the hook) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
