### PR TITLE
[DRK-19] Provider-aware sequence read for PostgreSQL

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -138,7 +138,7 @@
     <PackageVersion Include="TestContainers.Container.Database.MsSql" Version="1.5.4" />
     <PackageVersion Include="Testcontainers.Minio" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.8.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="X.PagedList.EF" Version="10.5.9" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/EfCore/DKNet.EfCore.Extensions/Extensions/EfCoreExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Extensions/EfCoreExtensions.cs
@@ -122,6 +122,15 @@ public static class EfCoreExtensions
                 StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        public bool IsNpgsql() =>
+            string.Equals(
+                context.Database.ProviderName,
+                "Npgsql.EntityFrameworkCore.PostgreSQL",
+                StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
         ///     Get the Next Sequence value
         /// </summary>
         /// <typeparam name="TEnum">The type of the enum representing the sequence.</typeparam>
@@ -139,6 +148,7 @@ public static class EfCoreExtensions
         /// <typeparam name="TEnum">The type of the enum representing the sequence.</typeparam>
         /// <param name="name">The name of the sequence.</param>
         /// <returns>The next value of the sequence.</returns>
+        /// <exception cref="NotSupportedException">Thrown when the database provider is neither SQL Server nor Npgsql.</exception>
         [SuppressMessage(
             "Security",
             "CA2100:Review SQL queries for security vulnerabilities",
@@ -152,8 +162,15 @@ public static class EfCoreExtensions
             var att = SequenceExtensions.GetAttribute(type);
             if (att == null) return null;
 
+            var sequenceName = SequenceExtensions.GetSequenceName(name);
+
             await using var command = context.Database.GetDbConnection().CreateCommand();
-            command.CommandText = $"SELECT NEXT VALUE FOR {att.Schema}.{SequenceExtensions.GetSequenceName(name)}";
+            command.CommandText = context.IsSqlServer()
+                ? $"SELECT NEXT VALUE FOR {att.Schema}.{sequenceName}"
+                : context.IsNpgsql()
+                    ? $"SELECT nextval('{att.Schema}.\"{sequenceName}\"')"
+                    : throw new NotSupportedException(
+                        $"Provider '{context.Database.ProviderName}' is not supported for sequence value generation.");
 
             await context.Database.OpenConnectionAsync();
             await using var result = await command.ExecuteReaderAsync();

--- a/src/EfCore/EfCore.Extensions.Tests/EfCore.Extensions.Tests.csproj
+++ b/src/EfCore/EfCore.Extensions.Tests/EfCore.Extensions.Tests.csproj
@@ -27,6 +27,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug"/>
         <PackageReference Include="Testcontainers.MsSql"/>
+        <PackageReference Include="Testcontainers.PostgreSql"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL"/>
         <PackageReference Include="Bogus"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Moq"/>

--- a/src/EfCore/EfCore.Extensions.Tests/Fixtures/PostgresFixture.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/Fixtures/PostgresFixture.cs
@@ -1,0 +1,57 @@
+using Testcontainers.PostgreSql;
+
+namespace EfCore.Extensions.Tests.Fixtures;
+
+public class PostgresFixture : IAsyncLifetime
+{
+    #region Fields
+
+    private readonly PostgreSqlContainer _pg = new PostgreSqlBuilder("postgres:16-alpine")
+        .Build();
+
+    #endregion
+
+    #region Properties
+
+    public MyDbContext? Db { get; private set; }
+
+    #endregion
+
+    #region Methods
+
+    public async Task DisposeAsync()
+    {
+        if (Db != null) await Db.DisposeAsync();
+
+        await _pg.StopAsync();
+        await _pg.DisposeAsync();
+    }
+
+    public string GetConnectionString(string dbName) =>
+        _pg.GetConnectionString()
+            .Replace("Database=postgres;", $"Database={dbName};", StringComparison.OrdinalIgnoreCase);
+
+    public async Task InitializeAsync()
+    {
+        await _pg.StartAsync();
+
+        var options = new DbContextOptionsBuilder()
+            .LogTo(
+                Console.WriteLine,
+                (eventId, logLevel) => logLevel >= LogLevel.Information
+                                       || eventId == RelationalEventId.CommandExecuting)
+            .EnableSensitiveDataLogging()
+            .EnableDetailedErrors()
+            .UseNpgsql(_pg.GetConnectionString())
+            .UseAutoConfigModel([typeof(MyDbContext).Assembly])
+
+            //DONOT use auto seeding here as there are a dedicated test for it
+            //.UseAutoDataSeeding()
+            .Options;
+
+        Db = new MyDbContext(options);
+        await Db.Database.EnsureCreatedAsync();
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Extensions.Tests/GlobalUsings.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/GlobalUsings.cs
@@ -11,4 +11,5 @@ global using Microsoft.Extensions.Logging;
 global using Xunit;
 global using Shouldly;
 global using Testcontainers.MsSql;
+global using Testcontainers.PostgreSql;
 global using EfCore.Extensions.Tests.Fixtures;

--- a/src/EfCore/EfCore.Extensions.Tests/NpgsqlSequenceTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/NpgsqlSequenceTests.cs
@@ -1,0 +1,148 @@
+namespace EfCore.Extensions.Tests;
+
+#pragma warning disable CA2012 // Use ValueTasks correctly
+
+public class NpgsqlSequenceTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>
+{
+    #region Fields
+
+    private readonly MyDbContext _db = fixture.Db!;
+
+    #endregion
+
+    #region Methods
+
+    [Fact]
+    public void DatabaseProvider_ShouldBeNpgsql()
+    {
+        // Act
+        var providerName = _db.Database.ProviderName;
+
+        // Assert
+        providerName.ShouldBe("Npgsql.EntityFrameworkCore.PostgreSQL");
+    }
+
+    [Fact]
+    public void IsNpgsql_WithPostgresProvider_ShouldReturnTrue()
+    {
+        // Act
+        var result = _db.IsNpgsql();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsSqlServer_WithPostgresProvider_ShouldReturnFalse()
+    {
+        // Act
+        var result = _db.IsSqlServer();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task NextSeqValue_WithValidSequence_ShouldReturnValue()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder()
+            .UseNpgsql(fixture.GetConnectionString("NpgsqlSequenceDb"))
+            .UseAutoConfigModel([typeof(DbContext).Assembly])
+            .Options;
+
+        await using var context = new DbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
+        await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
+        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_TestSequence1\" START WITH 100 INCREMENT BY 5");
+
+        // Act
+        var value = await context.NextSeqValue(TestSequenceTypes.TestSequence1);
+
+        // Assert
+        value.ShouldNotBeNull();
+        // Postgres nextval() always returns bigint (long)
+        value.ShouldBeAssignableTo<long>();
+        ((long)value).ShouldBeGreaterThanOrEqualTo(100);
+    }
+
+    [Fact]
+    public async Task NextSeqValueWithFormat_ShouldReturnFormattedValue()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder()
+            .UseNpgsql(fixture.GetConnectionString("NpgsqlFormatDb"))
+            .UseAutoConfigModel([typeof(TestSequenceTypes).Assembly])
+            .Options;
+
+        await using var context = new DbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
+        await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
+        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_TestSequence1\" START WITH 100 INCREMENT BY 5");
+
+        // Act
+        var formattedValue = await context.NextSeqValueWithFormat(TestSequenceTypes.TestSequence1);
+
+        // Assert
+        formattedValue.ShouldNotBeNullOrEmpty();
+        formattedValue.ShouldStartWith("TEST-");
+    }
+
+    [Fact]
+    public async Task NextSeqValue_WithSequencesTestEnum_ShouldReturnValue()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder()
+            .UseNpgsql(fixture.GetConnectionString("NpgsqlSequencesDb"))
+            .UseAutoConfigModel([typeof(MyDbContext).Assembly])
+            .Options;
+
+        await using var context = new MyDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
+        await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
+        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Invoice\" START WITH 1 INCREMENT BY 1 MAXVALUE 32767");
+        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Order\" START WITH 1 INCREMENT BY 1");
+        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Payment\" START WITH 1 INCREMENT BY 1");
+
+        // Act
+        // Postgres nextval() returns bigint, so use long
+        var val1 = await context.NextSeqValue<SequencesTest, long>(SequencesTest.Invoice);
+        var val2 = await context.NextSeqValue<SequencesTest, long>(SequencesTest.Order);
+
+        // Assert
+        val1!.Value.ShouldBeGreaterThan(0L);
+        val2!.Value.ShouldBeGreaterThan(0L);
+    }
+
+    [Fact]
+    public async Task NextSeqValueWithFormat_WithSequencesTestEnum_ShouldReturnFormattedValue()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder()
+            .UseNpgsql(fixture.GetConnectionString("NpgsqlFormatSeqDb"))
+            .UseAutoConfigModel([typeof(MyDbContext).Assembly])
+            .Options;
+
+        await using var context = new MyDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
+        await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
+        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Invoice\" START WITH 1 INCREMENT BY 1 MAXVALUE 32767");
+
+        // Act
+        var val = await context.NextSeqValueWithFormat(SequencesTest.Invoice);
+
+        // Assert
+        // NextSeqValueWithFormat uses DateTime.UtcNow internally, format: {0:yyMMdd}{1:00000}
+        val.ShouldStartWith(string.Format(CultureInfo.CurrentCulture, "T{0:yyMMdd}", DateTime.UtcNow));
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Extensions.Tests/UnsupportedProviderTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/UnsupportedProviderTests.cs
@@ -1,0 +1,99 @@
+namespace EfCore.Extensions.Tests;
+
+#pragma warning disable CA2012 // Use ValueTasks correctly
+
+public class UnsupportedProviderTests
+{
+    #region Methods
+
+    [Fact]
+    public async Task NextSeqValue_WithSqliteProvider_ShouldThrowNotSupportedException()
+    {
+        // Arrange
+        var dbPath = Path.Combine(Path.GetTempPath(), $"UnsupportedSeq_{Guid.NewGuid():N}.db");
+        try
+        {
+            var options = new DbContextOptionsBuilder()
+                .UseSqlite($"Data Source={dbPath}")
+                .UseAutoConfigModel([typeof(TestSequenceTypes).Assembly])
+                .Options;
+
+            await using var context = new DbContext(options);
+            await context.Database.EnsureCreatedAsync();
+
+            // Act & Assert
+            await Should.ThrowAsync<NotSupportedException>(async () =>
+                await context.NextSeqValue(TestSequenceTypes.TestSequence1));
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task NextSeqValue_WithSqliteProvider_ShouldContainProviderNameInMessage()
+    {
+        // Arrange
+        var dbPath = Path.Combine(Path.GetTempPath(), $"UnsupportedMsg_{Guid.NewGuid():N}.db");
+        try
+        {
+            var options = new DbContextOptionsBuilder()
+                .UseSqlite($"Data Source={dbPath}")
+                .UseAutoConfigModel([typeof(TestSequenceTypes).Assembly])
+                .Options;
+
+            await using var context = new DbContext(options);
+            await context.Database.EnsureCreatedAsync();
+
+            // Act
+            var ex = await Should.ThrowAsync<NotSupportedException>(async () =>
+                await context.NextSeqValue(TestSequenceTypes.TestSequence1));
+
+// Assert
+        ex.Message.ShouldContain(context.Database.ProviderName!);
+        }
+        finally
+        {
+            if (File.Exists(dbPath)) File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task IsNpgsql_WithSqliteProvider_ShouldReturnFalse()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder()
+            .UseSqlite("Data Source=:memory:")
+            .UseAutoConfigModel([typeof(TestSequenceTypes).Assembly])
+            .Options;
+
+        await using var context = new DbContext(options);
+
+        // Act
+        var result = context.IsNpgsql();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task IsSqlServer_WithSqliteProvider_ShouldReturnFalse()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder()
+            .UseSqlite("Data Source=:memory:")
+            .UseAutoConfigModel([typeof(TestSequenceTypes).Assembly])
+            .Options;
+
+        await using var context = new DbContext(options);
+
+        // Act
+        var result = context.IsSqlServer();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Extensions.Tests/WithSqlDbTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/WithSqlDbTests.cs
@@ -41,6 +41,26 @@ public class WithSqlDbTests(SqlServerFixture fixture) : IClassFixture<SqlServerF
     }
 
     [Fact]
+    public void IsSqlServer_WithSqlServerProvider_ShouldReturnTrue()
+    {
+        // Act
+        var result = _db.IsSqlServer();
+
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsNpgsql_WithSqlServerProvider_ShouldReturnFalse()
+    {
+        // Act
+        var result = _db.IsNpgsql();
+
+        // Assert
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task NextSeqValueWithFormat_WithEmptyFormatString_ShouldReturnValueAsString()
     {
         // This test verifies the format processing logic


### PR DESCRIPTION
### Summary

Provider-aware sequence read for PostgreSQL compatibility.

### Changes

- **`NextSeqValue<TEnum>`**: branches command text by database provider:
  - SQL Server → `SELECT NEXT VALUE FOR {schema}.{name}` (unchanged)
  - Npgsql → `SELECT nextval('{schema}."{name}"')` (double-quoted identifier inside regclass literal)
  - Other providers → throws `NotSupportedException`
- **`IsNpgsql()`**: new public accessor mirroring `IsSqlServer()`, comparing `ProviderName` to `"Npgsql.EntityFrameworkCore.PostgreSQL"`
- **Tests**: Npgsql sequence read via testcontainer, SqlServer regression check, unsupported provider assertion

### Package version

Next auto-computed version, expected `v10.0.30` (patch bump) once merged and published — versions are CI-computed from git tags (`paulhatch/semantic-version`), current tag `v10.0.29`. No manual version file was edited.