### PR TITLE
[DRK-33] DKNet.EfCore.Extensions: auto-register enum sequences on PostgreSQL + drop Seq_None

### DIFF
--- a/src/EfCore/DKNet.EfCore.Extensions/Extensions/SequenceExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Extensions/SequenceExtensions.cs
@@ -10,9 +10,11 @@ internal static class SequenceExtensions
     internal static SqlSequenceAttribute? GetAttribute(Type enumType) =>
         enumType.GetCustomAttribute<SqlSequenceAttribute>();
 
+    internal static SequenceAttribute? GetFieldAttribute(Type enumType, object field) =>
+        enumType.GetMember(field.ToString()!)[0].GetCustomAttribute<SequenceAttribute>();
+
     internal static SequenceAttribute GetFieldAttributeOrDefault(Type enumType, object field) =>
-        enumType.GetMember(field.ToString()!)[0].GetCustomAttribute<SequenceAttribute>() ??
-        new SequenceAttribute();
+        GetFieldAttribute(enumType, field) ?? new SequenceAttribute();
 
     internal static string GetSequenceName(object field) => $"Seq_{field}";
 
@@ -43,7 +45,9 @@ internal static class SequenceExtensions
 
             foreach (var f in fields)
             {
-                var fieldAtt = GetFieldAttributeOrDefault(enumType, f);
+                var fieldAtt = GetFieldAttribute(enumType, f);
+                if (fieldAtt == null) continue;
+
                 var name = GetSequenceName(f);
 
                 var seq = modelBuilder.HasSequence(fieldAtt.Type, name, att.Schema);

--- a/src/EfCore/DKNet.EfCore.Extensions/Internal/AutoConfigModelCustomizer.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Internal/AutoConfigModelCustomizer.cs
@@ -23,7 +23,7 @@ internal sealed class AutoConfigModelCustomizer(ModelCustomizer original) : IMod
         modelBuilder.RegisterGlobalModelBuilders(assemblies, dbContext);
 
         //Register Sequence
-        if (dbContext.IsSqlServer()) modelBuilder.RegisterSequences(assemblies);
+        if (dbContext.IsSqlServer() || dbContext.IsNpgsql()) modelBuilder.RegisterSequences(assemblies);
     }
 
     public void Customize(ModelBuilder modelBuilder, DbContext context)

--- a/src/EfCore/EfCore.Extensions.Tests/NpgsqlSequenceRegistrationTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/NpgsqlSequenceRegistrationTests.cs
@@ -1,0 +1,110 @@
+namespace EfCore.Extensions.Tests;
+
+#pragma warning disable CA2012 // Use ValueTasks correctly
+
+/// <summary>
+///     Regression tests for sequence registration on Npgsql.
+///     Verifies annotated members get sequences and unannotated members (Seq_None) do not.
+/// </summary>
+public class NpgsqlSequenceRegistrationTests(PostgresFixture fixture) : IClassFixture<PostgresFixture>
+{
+    #region Fields
+
+    private readonly MyDbContext _db = fixture.Db!;
+
+    #endregion
+
+    #region Methods
+
+    [Fact]
+    public void Model_ShouldContainSequenceForAnnotatedInvoice()
+    {
+        var seq = _db.Model.FindSequence("Seq_Invoice", "seq");
+        seq.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Model_ShouldContainSequenceForAnnotatedPayment()
+    {
+        var seq = _db.Model.FindSequence("Seq_Payment", "seq");
+        seq.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Model_ShouldContainSequenceForAnnotatedTestSequence1()
+    {
+        var seq = _db.Model.FindSequence("Seq_TestSequence1", "seq");
+        seq.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Model_ShouldNotContainSequenceForUnannotatedOrder()
+    {
+        // Order has no [Sequence] attribute — regression test for Seq_None removal.
+        // Previously, ALL enum members would be treated as having a default SequenceAttribute;
+        // now only members with an explicit [Sequence] attribute get a sequence.
+        var seq = _db.Model.FindSequence("Seq_Order", "seq");
+        seq.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Sequences_ShouldExistInDatabaseForAnnotatedMembers()
+    {
+        // Verify physical sequences exist in Postgres for annotated members.
+        var options = new DbContextOptionsBuilder()
+            .UseNpgsql(fixture.GetConnectionString("NpgsqlRegDb"))
+            .UseAutoConfigModel([typeof(MyDbContext).Assembly])
+            .Options;
+
+        await using var context = new MyDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        var names = await context.Database
+            .SqlQueryRaw<string>(
+                "SELECT sequencename FROM pg_catalog.pg_sequences WHERE sequencename LIKE 'Seq_%'")
+            .ToListAsync();
+
+        names.ShouldContain("Seq_Invoice");
+        names.ShouldContain("Seq_Payment");
+        names.ShouldNotContain("Seq_Order");
+    }
+
+    [Fact]
+    public void AutoConfigModelCustomizer_ShouldNotRegisterSequencesForUnsupportedProvider()
+    {
+        // The gate in AutoConfigModelCustomizer is dbContext.IsSqlServer() || dbContext.IsNpgsql().
+        // Sqlite should NOT trigger sequence registration.
+        var options = new DbContextOptionsBuilder()
+            .UseSqlite("Data Source=:memory:")
+            .UseAutoConfigModel([typeof(TestSequenceTypes).Assembly])
+            .Options;
+
+        using var context = new DbContext(options);
+        context.Database.EnsureCreated();
+
+        var sequences = context.Model.GetSequences().ToList();
+        sequences.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task RegisterSequencesFromEnumType_ShouldSkipUnannotatedFields()
+    {
+        // Direct test of the RegisterSequences logic: create a fresh Npgsql context,
+        // verify the generated DDL contains CREATE SEQUENCE for annotated members
+        // and does NOT contain it for unannotated Order.
+        var options = new DbContextOptionsBuilder()
+            .UseNpgsql(fixture.GetConnectionString("NpgsqlScriptDb"))
+            .UseAutoConfigModel([typeof(MyDbContext).Assembly])
+            .Options;
+
+        await using var context = new MyDbContext(options);
+        var script = context.Database.GenerateCreateScript();
+
+        script.ShouldContain("CREATE SEQUENCE", Case.Insensitive);
+        script.ShouldContain("\"Seq_Invoice\"");
+        script.ShouldContain("\"Seq_Payment\"");
+        script.ShouldNotContain("\"Seq_Order\"");
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Extensions.Tests/NpgsqlSequenceTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/NpgsqlSequenceTests.cs
@@ -54,7 +54,10 @@ public class NpgsqlSequenceTests(PostgresFixture fixture) : IClassFixture<Postgr
         await using var context = new DbContext(options);
         await context.Database.EnsureCreatedAsync();
 
-        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
+        // Manual create still needed: this scans typeof(DbContext).Assembly (EF Core's own assembly), which
+        // never contains TestSequenceTypes, so nothing gets auto-registered regardless of provider. Contrast
+        // with NextSeqValueWithFormat_ShouldReturnFormattedValue below, which scans the right assembly and
+        // needs no manual create now that Npgsql registration is enabled.
         await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
         await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_TestSequence1\" START WITH 100 INCREMENT BY 5");
 
@@ -80,7 +83,11 @@ public class NpgsqlSequenceTests(PostgresFixture fixture) : IClassFixture<Postgr
         await using var context = new DbContext(options);
         await context.Database.EnsureCreatedAsync();
 
-        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
+        // Manual create still required: EF's default ModelCacheKey is keyed on DbContext CLR type only, not
+        // on the assemblies passed to UseAutoConfigModel. Since NextSeqValue_WithValidSequence_ShouldReturnValue
+        // above also uses the plain DbContext type (with a different assemblies list), running the suite
+        // together can serve this test a stale cached model with no sequences - relying on auto-creation here
+        // would be order-dependent. This is a pre-existing model-caching characteristic, out of scope for this fix.
         await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
         await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_TestSequence1\" START WITH 100 INCREMENT BY 5");
 
@@ -104,11 +111,11 @@ public class NpgsqlSequenceTests(PostgresFixture fixture) : IClassFixture<Postgr
         await using var context = new MyDbContext(options);
         await context.Database.EnsureCreatedAsync();
 
-        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
+        // Seq_Invoice/Seq_Payment are now auto-created by EnsureCreatedAsync (annotated with [Sequence]).
+        // Seq_Order still needs a manual create: Order has no [Sequence] attribute, so the registration-loop
+        // fix (skip non-annotated members) deliberately excludes it from the model on every provider.
         await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
-        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Invoice\" START WITH 1 INCREMENT BY 1 MAXVALUE 32767");
         await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Order\" START WITH 1 INCREMENT BY 1");
-        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Payment\" START WITH 1 INCREMENT BY 1");
 
         // Act
         // Postgres nextval() returns bigint, so use long
@@ -132,9 +139,8 @@ public class NpgsqlSequenceTests(PostgresFixture fixture) : IClassFixture<Postgr
         await using var context = new MyDbContext(options);
         await context.Database.EnsureCreatedAsync();
 
-        // ponytail: HasSequence not supported by Npgsql at runtime, create manually
-        await context.Database.ExecuteSqlRawAsync("CREATE SCHEMA IF NOT EXISTS seq");
-        await context.Database.ExecuteSqlRawAsync("CREATE SEQUENCE IF NOT EXISTS seq.\"Seq_Invoice\" START WITH 1 INCREMENT BY 1 MAXVALUE 32767");
+        // No manual create needed: Invoice carries [Sequence], so EnsureCreatedAsync auto-creates
+        // Seq_Invoice on Npgsql now that registration is enabled for this provider.
 
         // Act
         var val = await context.NextSeqValueWithFormat(SequencesTest.Invoice);


### PR DESCRIPTION
## Summary

DRK-33 — `DKNet.EfCore.Extensions`: auto-register enum sequences on PostgreSQL (Npgsql) and stop emitting the junk `Seq_None` sequence.

Two fixes, both in the sequence registration path so every consumer (incl. DKNet.Templates) benefits:

1. **Registration now fires on Npgsql too.** `AutoConfigModelCustomizer.cs` widened the gate from `IsSqlServer()` to `IsSqlServer() || IsNpgsql()`. The read path already branched SqlServer / Npgsql; only the registration side was missed, so on PostgreSQL `[SqlSequence]`-annotated enum sequences were never added to the model.
2. **Non-annotated enum members are skipped.** `RegisterSequencesFromEnumType` now uses a nullable `GetFieldAttribute` and `continue`s when the member has no `[Sequence]` attribute. Only explicitly-annotated values (e.g. `Membership`) get a sequence, so the meaningless `Seq_None` for the `None = 0` sentinel is gone on every provider. The read-path `GetFieldAttributeOrDefault` is left untouched.

## Verification

- Full suite green, zero errors/warnings (52 projects).
- 100% line coverage on both touched files (`AutoConfigModelCustomizer.cs`, `SequenceExtensions.cs`), over the >90% bar.
- Npgsql verified via a **generated EF Core migration** (DDL emits `CREATE SEQUENCE` only for annotated members) and physically against `pg_catalog.pg_sequences` — `Seq_None` regression covered directly.
- SQL Server: read-through code review only (one-line `||` widening, no other logic touched), consistent with the ARM/TestContainers constraint; accepted as working as-is.
- Pre-existing `ModelCacheKey` caching workaround left untouched.

## Out of scope

NuGet republish of `DKNet.EfCore.Extensions` and the `DKNet.Templates` `OnModelCreating` stopgap removal are separate follow-on steps once this PR merges.
