### PR TITLE
[DRK-39] Safely coerce dynamic predicate filter values (convert-or-skip)

### DIFF
--- a/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateBuilderExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateBuilderExtensions.cs
@@ -229,11 +229,15 @@ internal static class DynamicPredicateBuilderExtensions
 
         var enumType = type.GetNonNullableType();
 
-        // Handle array/collection of values (for In/NotIn operations)
+        // Handle single value: TryCoerceValue converts it to the enum type further down the pipeline,
+        // so any value convertible to the underlying enum type is acceptable here.
         if (value is not (IEnumerable enumerable and not string)) return enumType.TryConvertToEnum(value, out _);
-        return enumerable.OfType<object>().All(item => enumType.TryConvertToEnum(item, out _));
 
-        // Handle single value
+        // Handle array/collection of values (for In/NotIn operations): element-wise coercion is out of
+        // scope (DRK-39), so an array is only valid when its elements are already the enum type itself
+        // (e.g. OrderStatus[]) - an int[]/string[] would reach the Dynamic LINQ parser unconverted and
+        // throw on Contains() type-mismatch, so it must be rejected here instead.
+        return enumerable.OfType<object>().All(enumType.IsInstanceOfType);
     }
 
     /// <summary>

--- a/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateBuilderExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateBuilderExtensions.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Collections;
+using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using DKNet.EfCore.Specifications.Extensions;
@@ -39,6 +40,15 @@ internal static class DynamicPredicateBuilderExtensions
         "SqlCommand", "SqlConnection", "DbCommand",
         "Runtime.", "Unsafe.", "Marshal.",
         "AppDomain.", "Thread.", "Task.Run"
+    ];
+
+    /// <summary>
+    ///     Non-enum target types (besides numeric types, covered by <c>IsNumericType</c>)
+    ///     that <c>TryCoerceValue</c> knows how to convert a value into.
+    /// </summary>
+    private static readonly HashSet<Type> CoercibleNonEnumTypes =
+    [
+        typeof(bool), typeof(DateTime), typeof(DateOnly), typeof(TimeOnly), typeof(Guid)
     ];
 
     #endregion
@@ -224,6 +234,73 @@ internal static class DynamicPredicateBuilderExtensions
         return enumerable.OfType<object>().All(item => enumType.TryConvertToEnum(item, out _));
 
         // Handle single value
+    }
+
+    /// <summary>
+    ///     Attempts to coerce a scalar filter value to the resolved property's non-nullable CLR type, so
+    ///     that values arriving as strings (query strings, JSON bodies, UI forms) can be used against
+    ///     numeric, boolean, date/time, <see cref="Guid" />, and enum properties without throwing at
+    ///     Dynamic LINQ parse time.
+    /// </summary>
+    /// <param name="propertyType">The resolved property type (can be a nullable value type).</param>
+    /// <param name="value">The filter value to coerce (can be null).</param>
+    /// <param name="coerced">
+    ///     When this method returns, the coerced value: <see langword="null" /> when <paramref name="value" />
+    ///     is <see langword="null" />, the original <paramref name="value" /> when no coercion was needed or
+    ///     applicable, or the converted value on a successful conversion.
+    /// </param>
+    /// <returns>
+    ///     <see langword="true" /> when <paramref name="value" /> is <see langword="null" />, is already
+    ///     assignable to <paramref name="propertyType" />, is not a type this method knows how to convert, or
+    ///     was successfully converted; <see langword="false" /> when conversion was attempted and failed.
+    /// </returns>
+    internal static bool TryCoerceValue(this Type propertyType, object? value, out object? coerced)
+    {
+        if (value == null)
+        {
+            coerced = null;
+            return true;
+        }
+
+        var targetType = propertyType.GetNonNullableType();
+        if (targetType.IsInstanceOfType(value))
+        {
+            coerced = value;
+            return true;
+        }
+
+        if (targetType.IsEnumType())
+            return targetType.TryConvertToEnum(value, out coerced);
+
+        if (!targetType.IsNumericType() && !CoercibleNonEnumTypes.Contains(targetType))
+        {
+            // Not a type we know how to coerce - leave the value as-is (unchanged behaviour).
+            coerced = value;
+            return true;
+        }
+
+        var text = value is string raw ? raw.Trim() : null;
+
+        try
+        {
+            coerced = targetType switch
+            {
+                _ when targetType == typeof(Guid) =>
+                    Guid.Parse(text ?? value.ToString()!, CultureInfo.InvariantCulture),
+                _ when targetType == typeof(DateOnly) =>
+                    DateOnly.Parse(text ?? value.ToString()!, CultureInfo.InvariantCulture),
+                _ when targetType == typeof(TimeOnly) =>
+                    TimeOnly.Parse(text ?? value.ToString()!, CultureInfo.InvariantCulture),
+                _ => Convert.ChangeType(text ?? value, targetType, CultureInfo.InvariantCulture)
+            };
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException
+                                        or ArgumentException)
+        {
+            coerced = null;
+            return false;
+        }
     }
 
     #endregion

--- a/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Dynamics/DynamicPredicateExtensions.cs
@@ -51,15 +51,21 @@ public static class DynamicPredicateExtensions
         if (!propType.ValidateEnumValue(value))
             return null;
 
+        // Coerce scalar values (e.g. strings) to the property's CLR type; In/NotIn arrays are left untouched
+        var coercedValue = value;
+        if (operation is not (Ops.In or Ops.NotIn) && !propType.TryCoerceValue(value, out coercedValue))
+            return null;
+
         // Build the dynamic LINQ predicate string using shared BuildClause method
-        var predicateString = DynamicPredicateBuilderExtensions.BuildClause(normalizedPath, op, value, 0);
+        var predicateString = DynamicPredicateBuilderExtensions.BuildClause(normalizedPath, op, coercedValue, 0);
 
 
         // Use System.Linq.Dynamic.Core to parse the predicate string
         // For In/NotIn, value is the array passed as @0 parameter
-        var lambda = value == null
+        var lambda = coercedValue == null
             ? DynamicExpressionParser.ParseLambda<T, bool>(ParsingConfig.Default, false, predicateString)
-            : DynamicExpressionParser.ParseLambda<T, bool>(ParsingConfig.Default, false, predicateString, value);
+            : DynamicExpressionParser.ParseLambda<T, bool>(ParsingConfig.Default, false, predicateString,
+                coercedValue);
 
         return lambda;
     }
@@ -71,6 +77,10 @@ public static class DynamicPredicateExtensions
         /// <summary>
         ///     Adds a dynamic condition using AND.
         /// </summary>
+        /// <remarks>
+        ///     If <paramref name="value" /> cannot be converted to the target property's type, the condition
+        ///     is silently skipped and the predicate is returned unchanged, rather than throwing.
+        /// </remarks>
         /// <param name="propertyName">Property name or dotted path.</param>
         /// <param name="operation">Filter operation.</param>
         /// <param name="value">Filter value.</param>
@@ -84,6 +94,10 @@ public static class DynamicPredicateExtensions
         /// <summary>
         ///     Adds a dynamic condition using OR.
         /// </summary>
+        /// <remarks>
+        ///     If <paramref name="value" /> cannot be converted to the target property's type, the condition
+        ///     is silently skipped and the predicate is returned unchanged, rather than throwing.
+        /// </remarks>
         /// <param name="propertyName">Property name or dotted path.</param>
         /// <param name="operation">Filter operation.</param>
         /// <param name="value">Filter value.</param>
@@ -130,6 +144,10 @@ public static class DynamicPredicateExtensions
         /// <summary>
         ///     Adds a dynamic condition using AND.
         /// </summary>
+        /// <remarks>
+        ///     If <paramref name="value" /> cannot be converted to the target property's type, the condition
+        ///     is silently skipped and the predicate is returned unchanged, rather than throwing.
+        /// </remarks>
         /// <param name="propertyName">Property name or dotted path.</param>
         /// <param name="operation">Filter operation.</param>
         /// <param name="value">Filter value.</param>
@@ -143,6 +161,10 @@ public static class DynamicPredicateExtensions
         /// <summary>
         ///     Adds a dynamic condition using OR.
         /// </summary>
+        /// <remarks>
+        ///     If <paramref name="value" /> cannot be converted to the target property's type, the condition
+        ///     is silently skipped and the predicate is returned unchanged, rather than throwing.
+        /// </remarks>
         /// <param name="propertyName">Property name or dotted path.</param>
         /// <param name="operation">Filter operation.</param>
         /// <param name="value">Filter value.</param>

--- a/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateExtensionsAdvancedTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateExtensionsAdvancedTests.cs
@@ -271,14 +271,21 @@ public class DynamicPredicateExtensionsAdvancedTests(TestDbFixture fixture, ITes
     }
 
     [Fact]
-    public void DynamicAnd_WithInOperation_EnumIntArray_ReturnsMatchingRecords()
+    public void DynamicAnd_WithInOperation_EnumIntArray_ReturnsOriginalPredicate()
     {
-        // Arrange - Using int values for enum
+        // Arrange - int[] element-wise coercion for enum In/NotIn is out of scope (DRK-39);
+        // the condition must be skipped gracefully instead of throwing (DRK-47).
         var statusValues = new[] { 0, 1, 2, 3 }; // Pending = 0, Processing = 1, Shipped = 2, Delivered = 3
-        var action = () => PredicateBuilder.New<Order>(true)
-            .DynamicAnd("Status", Ops.In, statusValues);
+        var predicate = PredicateBuilder.New<Order>(o => o.TotalAmount > 0);
 
-        action.ShouldThrow<InvalidOperationException>();
+        // Act
+        var result = predicate.DynamicAnd("Status", Ops.In, statusValues);
+
+        // Assert
+        var query = _context.Orders.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+        sql.ShouldNotContain("IN"); // Should not have IN clause
+        sql.ShouldContain("\"TotalAmount\""); // Should only have original condition
     }
 
     [Fact]

--- a/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateValueCoercionTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateValueCoercionTests.cs
@@ -214,17 +214,20 @@ public class DynamicPredicateValueCoercionTests(TestDbFixture fixture) : IClassF
 
     #endregion
 
-    #region Regression — int[] to enum In filter
+    #region Regression — int[] to enum In filter (DRK-47)
 
     [Fact]
-    public void DynamicAnd_WithIntArrayForEnumInFilter_ThrowsOnTypeMismatch()
+    public void DynamicAnd_WithIntArrayForEnumInFilter_SkipsConditionGracefully()
     {
         var statusValues = new[] { 0, 1, 2, 3 };
+        var basePredicate = PredicateBuilder.New<Order>(o => o.TotalAmount > 0);
 
-        var action = () => PredicateBuilder.New<Order>(true)
-            .DynamicAnd("Status", Ops.In, statusValues);
+        var result = basePredicate.DynamicAnd("Status", Ops.In, statusValues);
 
-        action.ShouldThrow<InvalidOperationException>();
+        var query = _context.Orders.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+        sql.ShouldNotContain("IN");
+        sql.ShouldContain("\"TotalAmount\"");
     }
 
     #endregion

--- a/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateValueCoercionTests.cs
+++ b/src/EfCore/EfCore.Specifications.Tests/DynamicPredicateValueCoercionTests.cs
@@ -1,0 +1,484 @@
+// <copyright file="DynamicPredicateValueCoercionTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+
+using DKNet.EfCore.Specifications.Dynamics;
+
+namespace EfCore.Specifications.Tests;
+
+/// <summary>
+///     BDD-style tests verifying value coercion behaviour in dynamic predicates
+///     (DRK-39 acceptance criteria).
+/// </summary>
+public class DynamicPredicateValueCoercionTests(TestDbFixture fixture) : IClassFixture<TestDbFixture>
+{
+    #region Fields
+
+    private readonly TestDbContext _context = fixture.Db!;
+
+    #endregion
+
+    #region AC 1 — Convertible string for numeric property
+
+    [Fact]
+    public void DynamicAnd_WithStringValueForDecimalProperty_CoercesAndFiltersCorrectly()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("Price", Ops.GreaterThan, "100");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var products = query.ToList();
+        products.ShouldAllBe(p => p.Price > 100m);
+    }
+
+    [Fact]
+    public void DynamicAnd_WithStringValueForIntProperty_CoercesAndFiltersCorrectly()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("StockQuantity", Ops.GreaterThanOrEqual, "10");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var products = query.ToList();
+        products.ShouldAllBe(p => p.StockQuantity >= 10);
+    }
+
+    #endregion
+
+    #region AC 2 — Unconvertible string for numeric property
+
+    [Fact]
+    public void DynamicAnd_WithUnconvertibleStringForDecimalProperty_ReturnsUnchangedPredicate()
+    {
+        var basePredicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+        var result = basePredicate.DynamicAnd("Price", Ops.GreaterThan, "abc");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+        var normalizedSql = NormalizeSql(sql);
+        normalizedSql.ShouldNotContain("abc");
+        normalizedSql.ShouldContain("isactive", Case.Insensitive);
+    }
+
+    [Fact]
+    public void DynamicAnd_WithUnconvertibleStringForIntProperty_ReturnsUnchangedPredicate()
+    {
+        var basePredicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+        var result = basePredicate.DynamicAnd("StockQuantity", Ops.LessThan, "xyz");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = NormalizeSql(query.ToQueryString());
+        sql.ShouldContain("isactive", Case.Insensitive);
+        sql.ShouldNotContain("xyz");
+    }
+
+    #endregion
+
+    #region AC 3 — Value already of correct type (no regression)
+
+    [Fact]
+    public async Task DynamicAnd_WithCorrectlyTypedDecimalValue_IsUnaffected()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate
+            .DynamicAnd("Price", Ops.GreaterThan, 100m)
+            .DynamicAnd("Price", Ops.LessThan, 1000m);
+
+        var products = await _context.Products.AsExpandable().Where(result).ToListAsync();
+        products.ShouldAllBe(p => p.Price > 100m && p.Price < 1000m);
+    }
+
+    [Fact]
+    public async Task DynamicAnd_WithCorrectlyTypedIntValue_IsUnaffected()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("StockQuantity", Ops.Equal, 50);
+
+        var products = await _context.Products.AsExpandable().Where(result).ToListAsync();
+        products.ShouldAllBe(p => p.StockQuantity == 50);
+    }
+
+    [Fact]
+    public async Task DynamicAnd_WithCorrectlyTypedBoolValue_IsUnaffected()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("IsActive", Ops.Equal, true);
+
+        var products = await _context.Products.AsExpandable().Where(result).ToListAsync();
+        products.ShouldAllBe(p => p.IsActive);
+    }
+
+    #endregion
+
+    #region AC 4 — Convertible string for DateTime
+
+    [Fact]
+    public void DynamicAnd_WithStringValueForDateTimeProperty_CoercesAndFiltersCorrectly()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+        var targetDate = new DateTime(2026, 1, 1);
+
+        var result = predicate.DynamicAnd("CreatedDate", Ops.GreaterThanOrEqual, "2026-01-01");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+        sql.ShouldContain("2026-01-01");
+
+        var products = query.ToList();
+        products.ShouldAllBe(p => p.CreatedDate >= targetDate);
+    }
+
+    #endregion
+
+    #region AC 5 — Null value semantics preserved
+
+    [Fact]
+    public void DynamicAnd_WithNullValueForNullableProperty_PreservesIsNullSemantics()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("Description", Ops.Equal, null);
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+        sql.ShouldContain("\"Description\" IS NULL");
+    }
+
+    [Fact]
+    public void DynamicAnd_WithNullValueForNullableStringProperty_NotEqual_GeneratesIsNotNull()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("Description", Ops.NotEqual, null);
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+        sql.ShouldContain("\"Description\" IS NOT NULL");
+    }
+
+    #endregion
+
+    #region AC 6 — SQL parameterization preserved
+
+    [Fact]
+    public void DynamicAnd_WithCoercedStringValue_ParameterizesSQLNotInterpolated()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("Price", Ops.GreaterThan, "100");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+
+        sql.ShouldContain("100");
+        sql.ShouldNotContain("'100'");
+    }
+
+    [Fact]
+    public void DynamicAnd_WithCoercedDateTimeString_ParameterizesSQLNotInterpolated()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("CreatedDate", Ops.GreaterThanOrEqual, "2026-01-01");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+
+        sql.ShouldContain("2026-01-01");
+        sql.ShouldNotContain("'2026-01-01'");
+    }
+
+    [Fact]
+    public async Task DynamicAnd_WithStringForBoolProperty_CoercesAndParameterizes()
+    {
+        var predicate = PredicateBuilder.New<Product>(true);
+
+        var result = predicate.DynamicAnd("IsActive", Ops.Equal, "true");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var sql = query.ToQueryString();
+        var products = await query.ToListAsync();
+
+        products.ShouldAllBe(p => p.IsActive);
+        sql.ShouldNotContain("'true'");
+        sql.ShouldNotContain("'True'");
+    }
+
+    #endregion
+
+    #region Regression — int[] to enum In filter
+
+    [Fact]
+    public void DynamicAnd_WithIntArrayForEnumInFilter_ThrowsOnTypeMismatch()
+    {
+        var statusValues = new[] { 0, 1, 2, 3 };
+
+        var action = () => PredicateBuilder.New<Order>(true)
+            .DynamicAnd("Status", Ops.In, statusValues);
+
+        action.ShouldThrow<InvalidOperationException>();
+    }
+
+    #endregion
+
+    #region DynamicOr coercion parity
+
+    [Fact]
+    public void DynamicOr_WithStringValueForDecimalProperty_CoercesAndCombines()
+    {
+        var predicate = PredicateBuilder.New<Product>(false);
+
+        var result = predicate
+            .DynamicOr("Price", Ops.GreaterThan, "500")
+            .DynamicOr("Name", Ops.StartsWith, "Special");
+
+        var query = _context.Products.AsExpandable().Where(result);
+        var products = query.ToList();
+        products.ShouldAllBe(p => p.Price > 500m || p.Name.StartsWith("Special"));
+    }
+
+    [Fact]
+    public async Task DynamicOr_WithUnconvertibleString_ReturnsUnchangedPredicate()
+    {
+        var basePredicate = PredicateBuilder.New<Product>(p => p.IsActive);
+
+        var result = basePredicate.DynamicOr("Price", Ops.GreaterThan, "not-a-number");
+
+        var products = await _context.Products.AsExpandable().Where(result).ToListAsync();
+        products.ShouldAllBe(p => p.IsActive);
+    }
+
+    #endregion
+
+    #region TryCoerceValue — internal method unit tests
+
+    [Fact]
+    public void TryCoerceValue_NullValue_ReturnsTrueAndNull()
+    {
+        typeof(decimal).TryCoerceValue(null, out var coerced).ShouldBeTrue();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_AlreadyAssignableDecimal_ReturnsTrueWithOriginalValue()
+    {
+        typeof(decimal).TryCoerceValue(100m, out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(100m);
+    }
+
+    [Fact]
+    public void TryCoerceValue_AlreadyAssignableInt_ReturnsTrueWithOriginalValue()
+    {
+        typeof(int).TryCoerceValue(42, out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(42);
+    }
+
+    [Fact]
+    public void TryCoerceValue_AlreadyAssignableString_ReturnsTrueWithOriginalValue()
+    {
+        typeof(string).TryCoerceValue("hello", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe("hello");
+    }
+
+    [Fact]
+    public void TryCoerceValue_EnumTypeWithValidStringValue_CoercesCorrectly()
+    {
+        typeof(OrderStatus).TryCoerceValue("0", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(OrderStatus.Pending);
+    }
+
+    [Fact]
+    public void TryCoerceValue_EnumTypeWithValidIntValue_CoercesCorrectly()
+    {
+        typeof(OrderStatus).TryCoerceValue(1, out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(OrderStatus.Processing);
+    }
+
+    [Fact]
+    public void TryCoerceValue_EnumTypeWithInvalidStringValue_ReturnsFalse()
+    {
+        typeof(OrderStatus).TryCoerceValue("NotAStatus", out var coerced).ShouldBeFalse();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_NonCoercibleNonEnumType_ReturnsTrueWithOriginalValue()
+    {
+        var complexObject = new Product();
+        typeof(Product).TryCoerceValue(complexObject, out var coerced).ShouldBeTrue();
+        coerced.ShouldBeSameAs(complexObject);
+    }
+
+    [Fact]
+    public void TryCoerceValue_DecimalString_CoercesCorrectly()
+    {
+        typeof(decimal).TryCoerceValue("123.45", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(123.45m);
+    }
+
+    [Fact]
+    public void TryCoerceValue_DecimalStringWithWhitespace_CoercesCorrectly()
+    {
+        typeof(decimal).TryCoerceValue(" 100 ", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(100m);
+    }
+
+    [Fact]
+    public void TryCoerceValue_IntString_CoercesCorrectly()
+    {
+        typeof(int).TryCoerceValue("42", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(42);
+    }
+
+    [Fact]
+    public void TryCoerceValue_DoubleString_CoercesCorrectly()
+    {
+        typeof(double).TryCoerceValue("3.14", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(3.14d);
+    }
+
+    [Fact]
+    public void TryCoerceValue_BoolStringTrue_CoercesCorrectly()
+    {
+        typeof(bool).TryCoerceValue("true", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(true);
+    }
+
+    [Fact]
+    public void TryCoerceValue_BoolStringFalse_CoercesCorrectly()
+    {
+        typeof(bool).TryCoerceValue("false", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(false);
+    }
+
+    [Fact]
+    public void TryCoerceValue_DateTimeString_CoercesCorrectly()
+    {
+        typeof(DateTime).TryCoerceValue("2026-01-01", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(new DateTime(2026, 1, 1));
+    }
+
+    [Fact]
+    public void TryCoerceValue_DateOnlyString_CoercesCorrectly()
+    {
+        typeof(DateOnly).TryCoerceValue("2026-06-15", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(new DateOnly(2026, 6, 15));
+    }
+
+    [Fact]
+    public void TryCoerceValue_TimeOnlyString_CoercesCorrectly()
+    {
+        typeof(TimeOnly).TryCoerceValue("13:45:30", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(new TimeOnly(13, 45, 30));
+    }
+
+    [Fact]
+    public void TryCoerceValue_GuidString_CoercesCorrectly()
+    {
+        var guid = Guid.NewGuid();
+        typeof(Guid).TryCoerceValue(guid.ToString(), out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(guid);
+    }
+
+    [Fact]
+    public void TryCoerceValue_InvalidDecimalString_ReturnsFalse()
+    {
+        typeof(decimal).TryCoerceValue("abc", out var coerced).ShouldBeFalse();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_InvalidIntString_ReturnsFalse()
+    {
+        typeof(int).TryCoerceValue("twelve", out var coerced).ShouldBeFalse();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_InvalidDateTimeString_ReturnsFalse()
+    {
+        typeof(DateTime).TryCoerceValue("not-a-date", out var coerced).ShouldBeFalse();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_InvalidGuidString_ReturnsFalse()
+    {
+        typeof(Guid).TryCoerceValue("not-a-guid", out var coerced).ShouldBeFalse();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_OverflowIntString_ReturnsFalse()
+    {
+        typeof(int).TryCoerceValue("99999999999999999999", out var coerced).ShouldBeFalse();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_NullableDecimalType_CoercesCorrectly()
+    {
+        typeof(decimal?).TryCoerceValue("200", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(200m);
+    }
+
+    [Fact]
+    public void TryCoerceValue_NullableIntTypeWithNull_ReturnsTrueAndNull()
+    {
+        typeof(int?).TryCoerceValue(null, out var coerced).ShouldBeTrue();
+        coerced.ShouldBeNull();
+    }
+
+    [Fact]
+    public void TryCoerceValue_LongString_CoercesCorrectly()
+    {
+        typeof(long).TryCoerceValue("9223372036854775807", out var coerced).ShouldBeTrue();
+        coerced.ShouldBe(9223372036854775807L);
+    }
+
+    #endregion
+
+    #region Expression-overload coercion parity
+
+    [Fact]
+    public async Task ExpressionOverload_DynamicAnd_WithStringForDecimalCoercesCorrectly()
+    {
+        Expression<Func<Product, bool>> predicate = p => p.IsActive;
+
+        var result = predicate.DynamicAnd("Price", Ops.GreaterThan, "100");
+
+        var products = await _context.Products.AsExpandable().Where(result).ToListAsync();
+        products.ShouldAllBe(p => p.IsActive && p.Price > 100m);
+    }
+
+    [Fact]
+    public async Task ExpressionOverload_DynamicAnd_WithUnconvertibleStringReturnsUnchanged()
+    {
+        Expression<Func<Product, bool>> predicate = p => p.IsActive;
+
+        var result = predicate.DynamicAnd("Price", Ops.GreaterThan, "abc");
+
+        var products = await _context.Products.AsExpandable().Where(result).ToListAsync();
+        products.ShouldAllBe(p => p.IsActive);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string NormalizeSql(string sql)
+        => sql
+            .Replace("\"", string.Empty, StringComparison.Ordinal)
+            .Replace("[", string.Empty, StringComparison.Ordinal)
+            .Replace("]", string.Empty, StringComparison.Ordinal);
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Implements safe value coercion in the dynamic predicate builder (`DKNet.EfCore.Specifications`). Filter values that arrive as strings (query strings, JSON bodies, UI forms) are now converted to the target property's CLR type **before** the Dynamic LINQ parse, instead of throwing and aborting the whole predicate build.

- **Convert-or-skip:** when a scalar value *can* be converted to the property type (numeric, bool, DateTime/DateOnly/TimeOnly, Guid, enum), it is converted and applied as a correctly-typed SQL parameter. When it *cannot*, that one condition is silently skipped (`DynamicAnd`/`DynamicOr` return the predicate unchanged) — the same graceful-skip convention already used for the other invalid-input paths.
- New internal helper `Type.TryCoerceValue` in `Dynamics/DynamicPredicateBuilderExtensions.cs`, mirroring the existing `ValidateArrayValue`/`ValidateEnumValue` helpers; reused `GetNonNullableType`, `IsEnumType`/`TryConvertToEnum`, `IsNumericType`, and `Convert.ChangeType(..., InvariantCulture)`.
- Called in `BuildDynamicExpression` (`Dynamics/DynamicPredicateExtensions.cs`) after `ValidateEnumValue`, before `BuildClause`, for scalar operations only (not `In`/`NotIn`).
- Documented the silent-skip behaviour in the XML docs of `DynamicAnd`/`DynamicOr`.
- No change to `In`/`NotIn` array element handling, the raw Dynamic-LINQ string overload, or `DKNet.Fw.Extensions`; values stay parameterized (`@0`), so no injection surface is introduced. An `int[]` passed to an enum `In`/`NotIn` filter now returns `null` (skipped) instead of throwing `InvalidOperationException`.

## Test coverage (from the verify stage)

- **`EfCore.Specifications.Tests/DynamicPredicateValueCoercionTests.cs`** (new, ~487 lines) — BDD-style coverage of the acceptance scenarios: convertible string → numeric/decimal applied; unconvertible string skipped (predicate equals base); correctly-typed value unaffected; convertible DateTime/DateOnly/TimeOnly/Guid/bool; null semantics preserved; parameterization preserved (no interpolation).
- **`EfCore.Specifications.Tests/DynamicPredicateExtensionsAdvancedTests.cs`** — extended regression for the `int[]`→enum `In` filter throwing case (now skipped).
- Also included: a fix ensuring `int[]` enum `In`/`NotIn` filters are skipped rather than thrown.

## Scope

Repo `baoduy/DKNet`, branch `dev`, package `DKNet.EfCore.Specifications` only. Behaviour change shipped as a bugfix-style fix in the next minor; no opt-in flag, no new public API.

> Note: silently skipping an unconvertible condition can widen a result set. Security-defining predicates must remain static `.And(...)` conditions, not dynamic user input (see spec Security Considerations).
