### PR TITLE
[DRK-73] test(efcore-extensions): Tier-2 arch rule — no System.Console in library code

### DIFF
--- a/src/EfCore/EfCore.Extensions.Tests/Architecture/ConsoleUsageArchitectureTests.cs
+++ b/src/EfCore/EfCore.Extensions.Tests/Architecture/ConsoleUsageArchitectureTests.cs
@@ -1,0 +1,66 @@
+using DKNet.EfCore.Extensions.Extensions;
+using NetArchTest.Rules;
+
+namespace EfCore.Extensions.Tests.ArchRules;
+
+/// <summary>
+///     Enforces that library code in <c>DKNet.EfCore.Extensions</c> never writes diagnostics through
+///     <see cref="System.Console" />. A framework primitive that writes to <c>Console</c> bypasses the host's
+///     logging configuration entirely — it cannot be filtered, redirected, redacted, or suppressed — and pollutes
+///     stdout in production. Diagnostics must go through an injected <c>ILogger</c> instead.
+///     <para>
+///         This is a Tier-2 baseline rule (architecture-review DRK-73): there is exactly one known offender today,
+///         <see cref="EfCoreExceptionHandler" /> (<c>EfCoreExceptionHandler.cs:61</c>), which is on the allow-list
+///         below. The allow-list must only ever SHRINK — when the offender is migrated to <c>ILogger</c>, delete its
+///         entry so the rule covers the whole assembly. Do not add new names to it.
+///     </para>
+/// </summary>
+public sealed class ConsoleUsageArchitectureTests
+{
+    #region Fields
+
+    /// <summary>
+    ///     Today's known offenders. Must only shrink — never add a name here to silence a new violation.
+    /// </summary>
+    private static readonly string[] KnownViolations = [nameof(EfCoreExceptionHandler)];
+
+    #endregion
+
+    #region Methods
+
+    [Fact]
+    public void ProductionTypes_ExceptKnownOffenders_MustNotDependOnSystemConsole()
+    {
+        var result = Types.InAssembly(typeof(EfCoreExceptionHandler).Assembly)
+            .That()
+            .DoNotHaveName(KnownViolations)
+            .Should()
+            .NotHaveDependencyOn("System.Console")
+            .GetResult();
+
+        var offenders = result.FailingTypeNames ?? [];
+        result.IsSuccessful.ShouldBeTrue(
+            "Library code must emit diagnostics through an injected ILogger, never System.Console, so hosts can " +
+            "filter/redirect/redact/suppress them. New offenders: " + string.Join(", ", offenders) +
+            ". Fix by injecting ILogger<T> instead of calling Console.*; do not add the type to the KnownViolations allow-list.");
+    }
+
+    [Fact]
+    public void Rule_CanDetectConsoleUsage_OnTheKnownOffender()
+    {
+        // Self-check: the allow-listed offender genuinely uses System.Console. If this ever passes, the rule above
+        // has gone blind (NetArchTest can no longer see the dependency) and would silently stop enforcing anything.
+        var result = Types.InAssembly(typeof(EfCoreExceptionHandler).Assembly)
+            .That()
+            .HaveName(nameof(EfCoreExceptionHandler))
+            .Should()
+            .NotHaveDependencyOn("System.Console")
+            .GetResult();
+
+        result.IsSuccessful.ShouldBeFalse(
+            "The known offender EfCoreExceptionHandler must still be detected as depending on System.Console; " +
+            "if this assertion fails the enforcement rule can no longer see Console usage and is worthless.");
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.Extensions.Tests/EfCore.Extensions.Tests.csproj
+++ b/src/EfCore/EfCore.Extensions.Tests/EfCore.Extensions.Tests.csproj
@@ -32,6 +32,7 @@
         <PackageReference Include="Bogus"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Moq"/>
+        <PackageReference Include="NetArchTest.Rules"/>
         <PackageReference Include="xunit"/>
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Part of the monthly architecture review **DRK-73**.

## What
Adds a **Tier-2 baseline** NetArchTest rule to `EfCore.Extensions.Tests` asserting that no type in the `DKNet.EfCore.Extensions` assembly depends on `System.Console`.

- `ProductionTypes_ExceptKnownOffenders_MustNotDependOnSystemConsole` — the rule. Passes today because the single known offender (`EfCoreExceptionHandler`, `EfCoreExceptionHandler.cs:61`) is on a `KnownViolations` allow-list. It **fails the moment any new `Console.*` usage appears** in the assembly.
- `Rule_CanDetectConsoleUsage_OnTheKnownOffender` — a self-check asserting the rule still detects the known offender, so the rule can never silently go blind.

## Why
A library primitive that writes to `Console` bypasses the host's logging configuration entirely — it cannot be filtered, redirected, redacted, or suppressed — and pollutes stdout in production. Diagnostics must go through an injected `ILogger`. The allow-list must **only shrink**: when `EfCoreExceptionHandler` is migrated to `ILogger`, delete its entry so the rule covers the whole assembly.

## Scope
- **Test-only / config-only.** No production code is modified.
- `EfCore.Extensions.Tests.csproj`: adds the centrally-managed `NetArchTest.Rules` package reference.
- New file: `Architecture/ConsoleUsageArchitectureTests.cs`.

## Verification
```
dotnet test EfCore.Extensions.Tests --filter FullyQualifiedName~ConsoleUsageArchitectureTests
Passed! - Failed: 0, Passed: 2
```
Full-solution `dotnet build DKNet.FW.sln -c Debug` is green (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
