### PR TITLE
[DRK-81] Fail loud when [Encrypted] is applied to PK/FK string columns

### DIFF
--- a/src/EfCore/DKNet.EfCore.Encryption/Extensions/ModelBuilderExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Encryption/Extensions/ModelBuilderExtensions.cs
@@ -26,10 +26,13 @@ public static class ModelBuilderExtensions
     ///     Thrown when <paramref name="modelBuilder" /> or
     ///     <paramref name="encryptionKeyProvider" /> is null.
     /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when a property marked with <see cref="EncryptedAttribute" /> is a primary key or foreign key,
+    ///     which is not supported.
+    /// </exception>
     /// <remarks>
     ///     This method scans all entity types in the model and applies encryption value converters
-    ///     to string properties that are not primary or foreign keys and are marked with the <see cref="EncryptedAttribute" />
-    ///     .
+    ///     to string properties marked with the <see cref="EncryptedAttribute" />.
     /// </remarks>
     public static void UseColumnEncryption(this ModelBuilder modelBuilder, IEncryptionKeyProvider encryptionKeyProvider)
     {
@@ -38,10 +41,7 @@ public static class ModelBuilderExtensions
 
         var stringProperties = modelBuilder.Model.GetEntityTypes()
             .SelectMany(e => e.GetProperties())
-            .Where(p =>
-                p.ClrType == typeof(string) &&
-                !p.IsPrimaryKey() &&
-                !p.IsForeignKey());
+            .Where(p => p.ClrType == typeof(string));
 
         foreach (var property in stringProperties)
         {
@@ -49,6 +49,12 @@ public static class ModelBuilderExtensions
             if (propertyInfo == null || !Attribute.IsDefined(propertyInfo, typeof(EncryptedAttribute)))
             {
                 continue;
+            }
+
+            if (property.IsPrimaryKey() || property.IsForeignKey())
+            {
+                throw new InvalidOperationException(
+                    $"Property '{propertyInfo.DeclaringType!.Name}.{propertyInfo.Name}' is marked with [Encrypted] but is a primary key or foreign key column, which is not supported.");
             }
 
             var key = encryptionKeyProvider.GetKey(propertyInfo.DeclaringType!);

--- a/src/EfCore/EfCore.Encryption.Tests/ModelBuilderExtensionsTests.cs
+++ b/src/EfCore/EfCore.Encryption.Tests/ModelBuilderExtensionsTests.cs
@@ -52,6 +52,39 @@ public class NoEncryptionEntity
     #endregion
 }
 
+public class EncryptedPrimaryKeyEntity
+{
+    #region Properties
+
+    [Encrypted][Key] public string Code { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    #endregion
+}
+
+public class ParentKeyEntity
+{
+    #region Properties
+
+    [Key] public string Code { get; set; } = string.Empty;
+
+    #endregion
+}
+
+public class EncryptedForeignKeyEntity
+{
+    #region Properties
+
+    [Key] public int Id { get; set; }
+
+    public ParentKeyEntity Parent { get; set; } = null!;
+
+    [Encrypted] public string ParentCode { get; set; } = string.Empty;
+
+    #endregion
+}
+
 // Test DbContext
 public class TestDbContext(DbContextOptions<TestDbContext> options, IEncryptionKeyProvider? keyProvider = null)
     : DbContext(options)
@@ -363,6 +396,37 @@ public class ModelBuilderExtensionsTests
         productEntityType.ShouldNotBeNull();
         productEntityType.FindProperty(nameof(ProductEntity.SecretFormula))
             ?.GetValueConverter().ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void UseColumnEncryption_WithEncryptedForeignKey_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<EncryptedForeignKeyEntity>()
+            .HasOne(e => e.Parent)
+            .WithMany()
+            .HasForeignKey(e => e.ParentCode);
+        var keyProvider = new TestKeyProvider();
+
+        // Act & Assert
+        var ex = Should.Throw<InvalidOperationException>(() => modelBuilder.UseColumnEncryption(keyProvider));
+        ex.Message.ShouldContain(nameof(EncryptedForeignKeyEntity));
+        ex.Message.ShouldContain(nameof(EncryptedForeignKeyEntity.ParentCode));
+    }
+
+    [Fact]
+    public void UseColumnEncryption_WithEncryptedPrimaryKey_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var modelBuilder = new ModelBuilder();
+        modelBuilder.Entity<EncryptedPrimaryKeyEntity>().HasKey(e => e.Code);
+        var keyProvider = new TestKeyProvider();
+
+        // Act & Assert
+        var ex = Should.Throw<InvalidOperationException>(() => modelBuilder.UseColumnEncryption(keyProvider));
+        ex.Message.ShouldContain(nameof(EncryptedPrimaryKeyEntity));
+        ex.Message.ShouldContain(nameof(EncryptedPrimaryKeyEntity.Code));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- `UseColumnEncryption` no longer silently skips `[Encrypted]` string properties that are primary or foreign keys — it now throws `InvalidOperationException` naming the entity type and property, since encryption of key columns is unsupported.
- Non-key `[Encrypted]` string properties keep encrypting exactly as before; PK/FK string properties without `[Encrypted]` remain unaffected.
- Added XML doc `<exception>` entry for the new failure mode.

## Testing
- `dotnet build DKNet.FW.sln -c Debug` — 0 warnings, 0 errors.
- `dotnet test EfCore.Encryption.Tests` — 103/103 passed (all pre-existing tests green, plus 2 new tests covering the `[Encrypted]` PK and FK throw cases).
- Coverage on `ModelBuilderExtensions`: 100%.
- Clean `dotnet pack`.

Only `ModelBuilderExtensions.cs` and `ModelBuilderExtensionsTests.cs` touched.
