### PR TITLE
[DRK-77] Make EventContext.GetEvents AdditionalData write idempotent

### DIFF
--- a/src/EfCore/DKNet.EfCore.Events/Internals/EventContext.cs
+++ b/src/EfCore/DKNet.EfCore.Events/Internals/EventContext.cs
@@ -45,7 +45,7 @@ internal sealed class EventContext(SnapshotContext snapshotContext, IMapper mapp
 
             foreach (var e in finalEvents)
             {
-                if (e is IEventItem item) item.AdditionalData.Add(nameof(sourceType), sourceType);
+                if (e is IEventItem item) item.AdditionalData[nameof(sourceType)] = sourceType;
                 yield return e;
             }
         }

--- a/src/EfCore/EfCore.Events.Tests/EventContextTests.cs
+++ b/src/EfCore/EfCore.Events.Tests/EventContextTests.cs
@@ -1,0 +1,59 @@
+using DKNet.EfCore.Abstractions.Events;
+using DKNet.EfCore.Events.Internals;
+using DKNet.EfCore.Extensions.Snapshots;
+using MapsterMapper;
+
+namespace EfCore.Events.Tests;
+
+public class EventContextTests(EventRunnerFixture fixture) : IClassFixture<EventRunnerFixture>
+{
+    #region Methods
+
+    [Fact]
+    public void GetEvents_CalledTwiceOverSameCachedEventInstance_OverwritesSourceTypeWithoutThrowing()
+    {
+        // Arrange
+        var db = fixture.Provider.GetRequiredService<DddContext>();
+        var mapper = fixture.Provider.GetRequiredService<IMapper>();
+
+        var root = new Root("Idempotent Root", "TestOwner");
+        root.AddEvent(new IdempotentTestEvent { Id = root.Id });
+        db.Set<Root>().Add(root);
+
+        using var snapshot = new SnapshotContext(db);
+        snapshot.Initialize();
+
+        var eventContext = new EventContext(snapshot, mapper);
+
+        // Act - first pass tags AdditionalData with sourceType (existing behaviour)
+        var firstPass = eventContext.GetEvents().Cast<IdempotentTestEvent>().ToList();
+
+        // Assert
+        firstPass.ShouldHaveSingleItem();
+        firstPass[0].AdditionalData["sourceType"].ShouldBe(typeof(Root).FullName);
+
+        // Act - second pass reprocesses the SAME IEventItem instance: EventHook only calls
+        // ClearEvents() after every publisher succeeds, so a failed publish leaves the entity's
+        // events queued and GetEvents() runs again over the already-tagged instance on retry.
+        var secondPass = Should.NotThrow(() => eventContext.GetEvents().Cast<IdempotentTestEvent>().ToList());
+
+        // Assert - overwritten, not duplicated, and the same instance as the first pass
+        secondPass.ShouldHaveSingleItem();
+        secondPass[0].ShouldBeSameAs(firstPass[0]);
+        secondPass[0].AdditionalData["sourceType"].ShouldBe(typeof(Root).FullName);
+        secondPass[0].AdditionalData.Count.ShouldBe(1);
+
+        db.Set<Root>().Remove(root);
+    }
+
+    #endregion
+}
+
+public sealed record IdempotentTestEvent : EventItem
+{
+    #region Properties
+
+    public required Guid Id { get; init; }
+
+    #endregion
+}


### PR DESCRIPTION
## Problem
`EventContext.GetEvents()` calls `item.AdditionalData.Add(nameof(sourceType), sourceType)` on each `IEventItem`. If a publisher throws in `EventHook.AfterSaveAsync`, the entity's events are never cleared, so the same `IEventItem` instance is reprocessed on the next `SaveChanges` — and `.Add` on an already-present key throws `ArgumentException`, permanently bricking that entity's future saves.

## Fix
Replace the `.Add` call with the idempotent indexer assignment `item.AdditionalData[nameof(sourceType)] = sourceType`, matching the existing indexer-access idiom already used elsewhere in this codebase (`SlimBusEventPublisher.cs`). No other behavior changes — the existing retry semantics (events stay uncleared until every publisher succeeds) are intentional and untouched.

## Testing
- New regression test: reprocesses the same cached `IEventItem` twice and asserts no throw, with `sourceType` overwritten.
- Full `EfCore.Events.Tests` + `EfCore.HookTests` suites green, 100% coverage on `EventContext.cs`, clean `dotnet pack`.

Architecture-review finding `DKNET-EVENT-001`, severity critical.