### PR TITLE
[DRK-74] Fix fail-open data-authorization owner filter (deny-all default)

### DIFF
--- a/src/EfCore/DKNet.EfCore.DataAuthorization/IDataOwnerDbContext.cs
+++ b/src/EfCore/DKNet.EfCore.DataAuthorization/IDataOwnerDbContext.cs
@@ -27,5 +27,18 @@ public interface IDataOwnerDbContext
     /// </remarks>
     IEnumerable<string> AccessibleKeys { get; }
 
+    /// <summary>
+    ///     Gets a value indicating whether the current context is exempt from ownership filtering entirely.
+    /// </summary>
+    /// <value>
+    ///     <c>true</c> to bypass the <see cref="AccessibleKeys" /> filter and see every row; otherwise <c>false</c>.
+    /// </value>
+    /// <remarks>
+    ///     This is an explicit, opt-in escape hatch for system or admin contexts. An empty
+    ///     <see cref="AccessibleKeys" /> collection must never be inferred as unrestricted access — the default
+    ///     is <c>false</c>, so an empty collection denies access to all owned rows.
+    /// </remarks>
+    bool IsUnrestrictedAccess => false;
+
     #endregion
 }

--- a/src/EfCore/DKNet.EfCore.DataAuthorization/Internals/DataOwnerAuthQuery.cs
+++ b/src/EfCore/DKNet.EfCore.DataAuthorization/Internals/DataOwnerAuthQuery.cs
@@ -44,13 +44,14 @@ internal sealed class DataOwnerAuthQuery : GlobalQueryFilter
             return null;
         }
 
-        // Capture the context in the closure so EF Core can evaluate AccessibleKeys per query
-        // Use !Any() instead of Count == 0 for better SQL translation
+        // Capture the context in the closure so EF Core can evaluate AccessibleKeys/IsUnrestrictedAccess per query
+        // An empty AccessibleKeys collection denies access by default (deny-all); only an explicit
+        // IsUnrestrictedAccess opt-in bypasses the filter
         // EF Core can translate Contains on IEnumerable<string> to SQL IN clause
         var capturedContext = dataOwnerContext;
 
         return x =>
-            !capturedContext.AccessibleKeys.Any()
+            capturedContext.IsUnrestrictedAccess
             || capturedContext.AccessibleKeys.Contains(((IOwnedBy)x).OwnedBy);
     }
 

--- a/src/EfCore/EfCore.DataAuthorization.Tests/AdditionalFixtures.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/AdditionalFixtures.cs
@@ -87,3 +87,49 @@ public sealed class EmptyAccessibleKeysFixture : IAsyncLifetime
 
     #endregion
 }
+
+/// <summary>
+///     A fixture that simulates unrestricted access, bypassing ownership filters
+///     even when accessible keys are restricted.
+/// </summary>
+public sealed class UnrestrictedAccessFixture : IAsyncLifetime
+{
+    #region Fields
+
+    private SqliteConnection? _connection;
+
+    #endregion
+
+    #region Properties
+
+    public ServiceProvider Provider { get; private set; } = null!;
+
+    #endregion
+
+    #region Methods
+
+    public async Task DisposeAsync()
+    {
+        if (_connection != null) await _connection.DisposeAsync();
+        await Provider.DisposeAsync();
+    }
+
+    public async Task InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        Provider = new ServiceCollection()
+            .AddLogging()
+            .AddDataOwnerProvider<UnrestrictedDddContext, NonEmptyAccessibleKeysProvider>()
+            .AddDbContextWithHook<UnrestrictedDddContext>(builder =>
+                builder.UseSqlite(_connection)
+                    .UseAutoConfigModel())
+            .BuildServiceProvider();
+
+        var db = Provider.GetRequiredService<UnrestrictedDddContext>();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
@@ -121,6 +121,11 @@ public class DataAuthorizationEmptyAccessibleKeysTests(EmptyAccessibleKeysFixtur
     #endregion
 }
 
+public class SimpleContext : DbContext
+{
+    public SimpleContext(DbContextOptions options) : base(options) { }
+}
+
 /// <summary>
 ///     Tests for the scenario where IsUnrestrictedAccess is opted into (true),
 ///     meaning all entities are visible regardless of the AccessibleKeys restriction.
@@ -163,4 +168,34 @@ public class DataAuthorizationUnrestrictedAccessTests(UnrestrictedAccessFixture 
     }
 
     #endregion
+}
+
+/// <summary>
+///     Tests for the internal filter logic.
+/// </summary>
+public class DataAuthorizationFilterTests
+{
+    [Fact]
+    public void HasQueryFilter_WithInvalidContext_ReturnsNull()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<SimpleContext>().UseSqlite("DataSource=:memory:").Options;
+        using var context = new SimpleContext(options);
+        var filter = new DataOwnerAuthQuery();
+
+        // Act
+        // Using reflection to call protected method
+        var method = typeof(DataOwnerAuthQuery).GetMethod("HasQueryFilter", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var genericMethod = method?.MakeGenericMethod(typeof(Root));
+        
+        object? result = null;
+        var ex = Record.Exception(() => {
+            result = genericMethod?.Invoke(filter, new object[] { context });
+        });
+
+        // Assert
+        // If Debug.Fail is called, it throws DebugAssertException
+        ex.ShouldNotBeNull();
+        result.ShouldBeNull();
+    }
 }

--- a/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
@@ -74,8 +74,8 @@ public class DataAuthorizationEmptyOwnerKeyTests(EmptyOwnerKeyFixture fixture)
 }
 
 /// <summary>
-///     Tests for the scenario where AccessibleKeys is empty, meaning all entities should be visible
-///     (super-user / admin context).
+///     Tests for the scenario where AccessibleKeys is empty and IsUnrestrictedAccess is not opted into,
+///     meaning no entities should be visible (deny-all default).
 /// </summary>
 public class DataAuthorizationEmptyAccessibleKeysTests(EmptyAccessibleKeysFixture fixture)
     : IClassFixture<EmptyAccessibleKeysFixture>
@@ -83,10 +83,10 @@ public class DataAuthorizationEmptyAccessibleKeysTests(EmptyAccessibleKeysFixtur
     #region Methods
 
     [Fact]
-    public async Task WhenAccessibleKeysIsEmpty_AllEntitiesAreVisible()
+    public async Task WhenAccessibleKeysIsEmpty_NoEntitiesAreVisible()
     {
         // Arrange: EmptyAccessibleKeysProvider returns [] for GetAccessibleKeys()
-        // The query filter's !AccessibleKeys.Any() == true branch is exercised → show ALL entities
+        // IsUnrestrictedAccess defaults to false, so Contains on an empty collection denies every row
         var db = fixture.Provider.GetRequiredService<DddContext>();
 
         var entity1 = new Root("Entity owned by Steven", "Steven");
@@ -96,14 +96,11 @@ public class DataAuthorizationEmptyAccessibleKeysTests(EmptyAccessibleKeysFixtur
         await db.AddRangeAsync(entity1, entity2, entity3);
         await db.SaveChangesAsync();
 
-        // Act: With empty AccessibleKeys, the query filter allows ALL entities
+        // Act: With empty AccessibleKeys and no opt-in, the query filter denies ALL entities
         var allEntities = await db.Set<Root>().ToListAsync();
 
-        // Assert: Entities with ANY OwnedBy value should be visible
-        allEntities.Count.ShouldBeGreaterThanOrEqualTo(3);
-        allEntities.ShouldContain(e => ((IOwnedBy)e).OwnedBy == "Steven");
-        allEntities.ShouldContain(e => ((IOwnedBy)e).OwnedBy == "other-user");
-        allEntities.ShouldContain(e => ((IOwnedBy)e).OwnedBy == "admin");
+        // Assert: No entities are visible regardless of OwnedBy value
+        allEntities.ShouldBeEmpty();
     }
 
     [Fact]

--- a/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/DataAuthorizationEdgeCaseTests.cs
@@ -120,3 +120,47 @@ public class DataAuthorizationEmptyAccessibleKeysTests(EmptyAccessibleKeysFixtur
 
     #endregion
 }
+
+/// <summary>
+///     Tests for the scenario where IsUnrestrictedAccess is opted into (true),
+///     meaning all entities are visible regardless of the AccessibleKeys restriction.
+/// </summary>
+public class DataAuthorizationUnrestrictedAccessTests(UnrestrictedAccessFixture fixture)
+    : IClassFixture<UnrestrictedAccessFixture>
+{
+    #region Methods
+
+    [Fact]
+    public async Task WhenUnrestrictedAccessIsTrue_AllEntitiesAreVisibleEvenWithRestrictedKeys()
+    {
+        // Arrange: NonEmptyAccessibleKeysProvider returns ["Steven"]
+        // IsUnrestrictedAccess is true, so the query filter should be bypassed
+        var db = fixture.Provider.GetRequiredService<UnrestrictedDddContext>();
+
+        var entity1 = new Root("Entity owned by Steven", "Steven");
+        var entity2 = new Root("Entity owned by other", "other-user");
+        var entity3 = new Root("Entity owned by admin", "admin");
+
+        await db.AddRangeAsync(entity1, entity2, entity3);
+        await db.SaveChangesAsync();
+
+        // Act: With unrestricted access, all entities are visible regardless of ownership
+        var allEntities = await db.Set<Root>().ToListAsync();
+
+        // Assert: All entities are visible
+        allEntities.Count.ShouldBe(3);
+        allEntities.ShouldContain(e => e.OwnedBy == "Steven");
+        allEntities.ShouldContain(e => e.OwnedBy == "other-user");
+        allEntities.ShouldContain(e => e.OwnedBy == "admin");
+    }
+
+    [Fact]
+    public void WhenUnrestrictedAccessIsTrue_AccessibleKeysAreStillProvided()
+    {
+        var db = fixture.Provider.GetRequiredService<UnrestrictedDddContext>();
+        db.IsUnrestrictedAccess.ShouldBeTrue();
+        db.AccessibleKeys.ShouldContain("Steven");
+    }
+
+    #endregion
+}

--- a/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/AdditionalProviders.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/AdditionalProviders.cs
@@ -15,8 +15,8 @@ internal class EmptyOwnerKeyProvider : IDataOwnerProvider
 }
 
 /// <summary>
-///     A data owner provider with no accessible keys, simulating a super-user context where
-///     all entities should be visible regardless of ownership.
+///     A data owner provider with no accessible keys, simulating a context that has not been granted
+///     access to any owned data — the deny-all default, since it does not opt into unrestricted access.
 /// </summary>
 internal class EmptyAccessibleKeysProvider : IDataOwnerProvider
 {

--- a/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/AdditionalProviders.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/AdditionalProviders.cs
@@ -24,3 +24,14 @@ internal class EmptyAccessibleKeysProvider : IDataOwnerProvider
 
     public string GetOwnershipKey() => "Steven";
 }
+
+/// <summary>
+///     A data owner provider with specific accessible keys, used to verify that
+///     unrestricted access bypasses these restrictions.
+/// </summary>
+internal class NonEmptyAccessibleKeysProvider : IDataOwnerProvider
+{
+    public ICollection<string> GetAccessibleKeys() => ["Steven"];
+
+    public string GetOwnershipKey() => "Steven";
+}

--- a/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/DddContext.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/DddContext.cs
@@ -16,6 +16,8 @@ public class DddContext(
 
     public IEnumerable<string> AccessibleKeys => _dataKeyProvider?.GetAccessibleKeys() ?? [];
 
+    public virtual bool IsUnrestrictedAccess => false;
+
     #endregion
 
     //Internal fields will be available in unit test project.
@@ -31,5 +33,5 @@ public class UnrestrictedDddContext(
     DbContextOptions options,
     IEnumerable<IDataOwnerProvider> dataKeyProviders) : DddContext(options, dataKeyProviders)
 {
-    public bool IsUnrestrictedAccess => true;
+    public override bool IsUnrestrictedAccess => true;
 }

--- a/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/DddContext.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/TestEntities/DddContext.cs
@@ -23,3 +23,13 @@ public class DddContext(
     // ReSharper disable once InconsistentNaming
     internal readonly IDataOwnerProvider _dataKeyProvider = dataKeyProviders.First();
 }
+
+/// <summary>
+///     A context that explicitly opts into unrestricted access to bypass ownership filtering.
+/// </summary>
+public class UnrestrictedDddContext(
+    DbContextOptions options,
+    IEnumerable<IDataOwnerProvider> dataKeyProviders) : DddContext(options, dataKeyProviders)
+{
+    public bool IsUnrestrictedAccess => true;
+}


### PR DESCRIPTION
## Summary

- `DataOwnerAuthQuery.HasQueryFilter` treated an empty `AccessibleKeys` collection as "show everything" (fail-open) — any context with no principal (background job, unauthenticated call, misconfigured provider) silently got cross-tenant read access.
- Empty keys now denies all rows by default. A context can only see everything by explicitly opting in via a new `IDataOwnerDbContext.IsUnrestrictedAccess` member (default `false`, non-breaking default-interface-member).
- `DddContext` (test project) implements `IsUnrestrictedAccess` as an explicit `virtual` member so subclasses can `override` it — a default interface member on its own isn't overridable by a derived class's same-named property.
- Inverted the one existing test that had locked in the fail-open behaviour as an intended "super-user" feature, and added coverage for the opt-in bypass path and the invalid-context branch.

## Security finding

Addresses architecture-review finding `SEC-001` (severity: critical), tracked as DRK-74.

## Test plan

- [x] `dotnet build DKNet.FW.sln -c Debug` — clean, 0 warnings, 0 errors
- [x] `EfCore.DataAuthorization.Tests` — 23/23 passing
- [x] Coverage on touched production files: 100% excluding two structurally unreachable lines (documented in DRK-103's sign-off — the interface's own default body, now unreachable since `DddContext` implements the member explicitly; and a `Debug.Fail` call under `[Conditional("DEBUG")]`)
- [x] Clean `dotnet pack` for `DKNet.EfCore.DataAuthorization`
