### PR TITLE
[DRK-83] ApplySpecs: IgnoreQueryFilters must not bypass non-ignorable global filters

### DIFF
--- a/src/EfCore/DKNet.EfCore.DataAuthorization/Internals/DataOwnerAuthQuery.cs
+++ b/src/EfCore/DKNet.EfCore.DataAuthorization/Internals/DataOwnerAuthQuery.cs
@@ -26,6 +26,9 @@ internal sealed class DataOwnerAuthQuery : GlobalQueryFilter
 
     public override string FilterKey => nameof(DataOwnerAuthQuery);
 
+    // Row-level tenant/owner isolation must never be silently disabled by a spec's IsIgnoreQueryFilters flag.
+    public override bool IsIgnorable => false;
+
     #endregion
 
     #region Methods

--- a/src/EfCore/DKNet.EfCore.Extensions/Configurations/GlobalQueryFilter.cs
+++ b/src/EfCore/DKNet.EfCore.Extensions/Configurations/GlobalQueryFilter.cs
@@ -4,6 +4,7 @@
 // File: GlobalQueryFilter.cs
 // Description: Base class to apply global query filters to entity types at model build time.
 
+using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -25,6 +26,13 @@ public abstract class GlobalQueryFilter : IGlobalModelBuilder
     private readonly MethodInfo _method = typeof(GlobalQueryFilter)
         .GetMethod(nameof(ApplyQueryFilter), BindingFlags.Instance | BindingFlags.NonPublic)!;
 
+    /// <summary>
+    ///     Tracks <see cref="IsIgnorable" /> by <see cref="FilterKey" /> for every <see cref="GlobalQueryFilter" />
+    ///     that has been applied to a model, so <see cref="IgnorableFilterKeys" /> can report which registered
+    ///     filters are safe to bypass.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, bool> KnownFilterKeys = new();
+
     #endregion
 
     #region Properties
@@ -34,6 +42,22 @@ public abstract class GlobalQueryFilter : IGlobalModelBuilder
     ///     Support from EF Core 10 onwards for named query filters.
     /// </summary>
     public abstract string FilterKey { get; }
+
+    /// <summary>
+    ///     Whether this filter may be bypassed via <c>ISpecification.IsIgnoreQueryFilters</c>. Defaults to
+    ///     <c>true</c>, preserving today's bypass behaviour for any filter that doesn't override it (e.g. a future
+    ///     soft-delete filter). Override to <c>false</c> for filters that must never be bypassed this way, such as
+    ///     row-level tenant/ownership isolation.
+    /// </summary>
+    public virtual bool IsIgnorable => true;
+
+    /// <summary>
+    ///     The <see cref="FilterKey" /> of every registered <see cref="GlobalQueryFilter" /> whose
+    ///     <see cref="IsIgnorable" /> is <c>true</c> — the set of filters that
+    ///     <c>SpecificationExtensions.ApplySpecs</c> is allowed to bypass.
+    /// </summary>
+    public static IReadOnlyCollection<string> IgnorableFilterKeys =>
+        KnownFilterKeys.Where(kv => kv.Value).Select(kv => kv.Key).ToArray();
 
     #endregion
 
@@ -47,6 +71,7 @@ public abstract class GlobalQueryFilter : IGlobalModelBuilder
     public void Apply(ModelBuilder modelBuilder, DbContext context)
     {
         var entityTypes = GetEntityTypes(modelBuilder);
+        KnownFilterKeys[FilterKey] = IsIgnorable;
 
         foreach (var entityType in entityTypes)
         {

--- a/src/EfCore/DKNet.EfCore.Specifications/Extensions/SpecificationExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Extensions/SpecificationExtensions.cs
@@ -1,3 +1,4 @@
+using DKNet.EfCore.Extensions.Configurations;
 using Microsoft.EntityFrameworkCore;
 
 namespace DKNet.EfCore.Specifications.Extensions;
@@ -22,7 +23,11 @@ internal static class SpecificationExtensions
     {
         ArgumentNullException.ThrowIfNull(specification);
 
-        if (specification.IsIgnoreQueryFilters) queryable = queryable.IgnoreQueryFilters();
+        if (specification.IsIgnoreQueryFilters)
+        {
+            var ignorableKeys = GlobalQueryFilter.IgnorableFilterKeys;
+            if (ignorableKeys.Count > 0) queryable = queryable.IgnoreQueryFilters(ignorableKeys);
+        }
 
         if (specification.FilterQuery is not null) queryable = queryable.Where(specification.FilterQuery);
 

--- a/src/EfCore/DKNet.EfCore.Specifications/Specification.cs
+++ b/src/EfCore/DKNet.EfCore.Specifications/Specification.cs
@@ -21,7 +21,9 @@ public interface ISpecification<TEntity>
     #region Properties
 
     /// <summary>
-    ///     Ignore the global query filters (e.g., for soft delete or multi-tenancy)
+    ///     Ignore global query filters that opt in to being bypassed (e.g., soft delete). Filters marked
+    ///     non-ignorable (e.g. row-level tenant/ownership isolation) are never bypassed by this flag, regardless
+    ///     of consuming application.
     /// </summary>
     bool IsIgnoreQueryFilters { get; }
 
@@ -117,8 +119,9 @@ public abstract class Specification<TEntity> : ISpecification<TEntity>
     public IReadOnlyCollection<Func<IQueryable<TEntity>, IQueryable<TEntity>>> IncludeBuilders => _includeBuilders;
 
     /// <summary>
-    ///     Gets a value indicating whether global query filters should be ignored for this specification.
-    ///     Call <see cref="IgnoreQueryFilters" /> to enable this behavior.
+    ///     Gets a value indicating whether ignorable global query filters should be bypassed for this
+    ///     specification. Non-ignorable filters (e.g. row-level tenant/ownership isolation) are never bypassed by
+    ///     this flag. Call <see cref="IgnoreQueryFilters" /> to enable this behavior.
     /// </summary>
     public bool IsIgnoreQueryFilters { get; private set; }
 
@@ -207,7 +210,9 @@ public abstract class Specification<TEntity> : ISpecification<TEntity>
         expression == null ? PredicateBuilder.New<TEntity>() : PredicateBuilder.New(expression);
 
     /// <summary>
-    ///     Instructs the specification to ignore global query filters (for example soft-delete filters).
+    ///     Instructs the specification to bypass global query filters that opt in to being ignorable (for
+    ///     example soft-delete filters). Non-ignorable filters (e.g. row-level tenant/ownership isolation) are
+    ///     never bypassed by this flag, regardless of consuming application.
     /// </summary>
     protected void IgnoreQueryFilters()
     {

--- a/src/EfCore/EfCore.DataAuthorization.Tests/EfCore.DataAuthorization.Tests.csproj
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/EfCore.DataAuthorization.Tests.csproj
@@ -36,5 +36,6 @@
     <ItemGroup>
         <ProjectReference Include="..\DKNet.EfCore.DataAuthorization\DKNet.EfCore.DataAuthorization.csproj"/>
         <ProjectReference Include="..\DKNet.EfCore.Abstractions\DKNet.EfCore.Abstractions.csproj"/>
+        <ProjectReference Include="..\DKNet.EfCore.Specifications\DKNet.EfCore.Specifications.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/EfCore/EfCore.DataAuthorization.Tests/IgnoreQueryFiltersTests.cs
+++ b/src/EfCore/EfCore.DataAuthorization.Tests/IgnoreQueryFiltersTests.cs
@@ -1,0 +1,177 @@
+using System.Linq.Expressions;
+using DKNet.EfCore.DataAuthorization.Internals;
+using DKNet.EfCore.Extensions.Configurations;
+using DKNet.EfCore.Hooks;
+using DKNet.EfCore.Specifications;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace EfCore.DataAuthorization.Tests;
+
+/// <summary>
+///     Grants access to "tenant-a" only, used to verify that <see cref="ISpecification{TEntity}.IsIgnoreQueryFilters" />
+///     never re-exposes rows owned by other tenants.
+/// </summary>
+internal sealed class TenantAAccessibleKeysProvider : IDataOwnerProvider
+{
+    public ICollection<string> GetAccessibleKeys() => ["tenant-a"];
+
+    public string GetOwnershipKey() => "tenant-a";
+}
+
+/// <summary>
+///     A <see cref="Specification{TEntity}" /> for <see cref="Root" /> that optionally requests
+///     <see cref="IsIgnoreQueryFilters" />, used to drive <c>ApplySpecs</c> in tests.
+/// </summary>
+internal sealed class RootSpec : Specification<Root>
+{
+    public RootSpec(bool ignoreQueryFilters)
+    {
+        if (ignoreQueryFilters) IgnoreQueryFilters();
+    }
+}
+
+public sealed class TenantIsolationFixture : IAsyncLifetime
+{
+    #region Fields
+
+    private SqliteConnection? _connection;
+
+    #endregion
+
+    #region Properties
+
+    public ServiceProvider Provider { get; private set; } = null!;
+
+    #endregion
+
+    #region Methods
+
+    public async Task DisposeAsync()
+    {
+        if (_connection != null) await _connection.DisposeAsync();
+        await Provider.DisposeAsync();
+    }
+
+    public async Task InitializeAsync()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        await _connection.OpenAsync();
+
+        Provider = new ServiceCollection()
+            .AddLogging()
+            .AddDataOwnerProvider<DddContext, TenantAAccessibleKeysProvider>()
+            .AddDbContextWithHook<DddContext>(builder =>
+                builder.UseSqlite(_connection)
+                    .UseAutoConfigModel())
+            .BuildServiceProvider();
+
+        var db = Provider.GetRequiredService<DddContext>();
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    #endregion
+}
+
+/// <summary>
+///     Regression tests for DRK-83: <c>ApplySpecs</c>' <see cref="ISpecification{TEntity}.IsIgnoreQueryFilters" />
+///     flag must only bypass global query filters that opt in via <see cref="GlobalQueryFilter.IsIgnorable" />,
+///     never the row-level tenant/owner isolation filter.
+/// </summary>
+public class IgnoreQueryFiltersTests(TenantIsolationFixture fixture) : IClassFixture<TenantIsolationFixture>
+{
+    #region Methods
+
+    [Fact]
+    public void DataOwnerAuthQuery_IsIgnorable_IsFalse()
+    {
+        new DataOwnerAuthQuery().IsIgnorable.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task ApplySpecs_TenantFilter_StaysApplied_WhenIsIgnoreQueryFiltersIsTrue()
+    {
+        var db = fixture.Provider.GetRequiredService<DddContext>();
+        db.AddRange(new Root("A-Item", "tenant-a"), new Root("B-Item", "tenant-b"));
+        await db.SaveChangesAsync();
+
+        var repo = new RepositorySpec<DddContext>(db);
+        var result = repo.Query(new RootSpec(true)).ToList();
+
+        result.ShouldNotBeEmpty();
+        result.ShouldAllBe(r => r.OwnedBy == "tenant-a");
+    }
+
+    [Fact]
+    public async Task ApplySpecs_IgnorableFilter_IsBypassed_WhenIsIgnoreQueryFiltersIsTrue()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        await using var db = new HiddenFlagDbContext(
+            new DbContextOptionsBuilder<HiddenFlagDbContext>().UseSqlite(connection).Options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Items.AddRange(
+            new HiddenFlagEntity { Id = 1, IsHidden = false },
+            new HiddenFlagEntity { Id = 2, IsHidden = true });
+        await db.SaveChangesAsync();
+
+        var repo = new RepositorySpec<HiddenFlagDbContext>(db);
+
+        repo.Query(new HiddenFlagSpec(false)).ToList()
+            .Select(x => x.Id).ShouldBe([1]);
+
+        repo.Query(new HiddenFlagSpec(true)).ToList()
+            .Select(x => x.Id).OrderBy(x => x).ShouldBe([1, 2]);
+    }
+
+    #endregion
+}
+
+/// <summary>Marker used by <see cref="TestOnlyIgnorableFilter" /> to locate the entities it filters.</summary>
+internal interface ITestHiddenFlag
+{
+    bool IsHidden { get; }
+}
+
+internal sealed class HiddenFlagEntity : ITestHiddenFlag
+{
+    public int Id { get; init; }
+    public bool IsHidden { get; init; }
+}
+
+/// <summary>
+///     A test-only <see cref="GlobalQueryFilter" /> that does not override <see cref="IsIgnorable" />, so it keeps
+///     the default bypassable behaviour — proving <c>ApplySpecs</c> still bypasses filters that opt in.
+/// </summary>
+internal sealed class TestOnlyIgnorableFilter : GlobalQueryFilter
+{
+    public override string FilterKey => nameof(TestOnlyIgnorableFilter);
+
+    protected override IEnumerable<IMutableEntityType> GetEntityTypes(ModelBuilder modelBuilder) =>
+        modelBuilder.Model.GetEntityTypes().Where(t => typeof(ITestHiddenFlag).IsAssignableFrom(t.ClrType));
+
+    protected override Expression<Func<TEntity, bool>>? HasQueryFilter<TEntity>(DbContext context) =>
+        x => !((ITestHiddenFlag)x).IsHidden;
+}
+
+internal sealed class HiddenFlagDbContext(DbContextOptions options) : DbContext(options)
+{
+    public DbSet<HiddenFlagEntity> Items => Set<HiddenFlagEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<HiddenFlagEntity>().HasKey(e => e.Id);
+        new TestOnlyIgnorableFilter().Apply(modelBuilder, this);
+    }
+}
+
+internal sealed class HiddenFlagSpec : Specification<HiddenFlagEntity>
+{
+    public HiddenFlagSpec(bool ignoreQueryFilters)
+    {
+        if (ignoreQueryFilters) IgnoreQueryFilters();
+    }
+}


### PR DESCRIPTION
## [DRK-83] SpecificationExtensions.ApplySpecs — IgnoreQueryFilters no longer strips the tenant/owner filter

**Problem**: `ApplySpecs` bypassed `IsIgnoreQueryFilters` via EF Core's all-or-nothing `queryable.IgnoreQueryFilters()`, which also disabled `DataOwnerAuthQuery` (row-level tenant/owner isolation) — a silent authorization bypass with no audit trail (SEC-001, high severity).

**Fix**:
- `GlobalQueryFilter` (`DKNet.EfCore.Extensions`) gains a virtual `IsIgnorable` flag (default `true`, backward compatible) and a static `IgnorableFilterKeys` registry populated as filters self-register.
- `SpecificationExtensions.ApplySpecs` now calls EF Core 10's keyed `IgnoreQueryFilters(filterKeys)` overload with only the opted-in keys, instead of the blanket parameterless call.
- `DataOwnerAuthQuery` overrides `IsIgnorable => false` — the actual security fix. Tenant/owner isolation can no longer be bypassed via a spec's convenience flag, in any consuming application.
- Doc-only update to `ISpecification.IsIgnoreQueryFilters` to stop claiming it covers multi-tenancy.

No new coupling between `DKNet.EfCore.Specifications` and `DKNet.EfCore.DataAuthorization` — both already reference `DKNet.EfCore.Extensions`, where the shared mechanism lives.

**Tests**: new `EfCore.DataAuthorization.Tests/IgnoreQueryFiltersTests.cs` covers the cross-tenant regression (rows owned by two different keys, `IsIgnoreQueryFilters = true`, only the accessible tenant's rows returned), `DataOwnerAuthQuery.IsIgnorable == false`, and that a filter which doesn't override `IsIgnorable` stays bypassable (no regression for that path).

**Coverage**: dev-qc confirmed ≥90% on touched classes; full suite green (`EfCore.Specifications.Tests`, `EfCore.DataAuthorization.Tests`, `EfCore.Repos.Tests`).

Branch was rebased against latest `dev` (several unrelated cycles — DRK-74, 76, 77, 78, 81 — had merged in the meantime); merge was clean, no conflicts.
