### PR TITLE
[DRK-80] Redact sensitive properties by default in EF Core audit logs (SEC-005)

### DIFF
--- a/docs/wiki/audit-logs.md
+++ b/docs/wiki/audit-logs.md
@@ -25,6 +25,14 @@ runs in the before-SaveChanges phase to populate or capture that information for
 tracked, flagged entities, so audit data is written consistently in the same
 transaction as the change.
 
+## Sensitive property redaction
+
+Captured property values are redacted by default: any property whose name matches a known sensitive pattern
+(passwords, secrets, tokens, connection strings, etc.) is recorded as `***REDACTED***` instead of its real value.
+Apply `[AuditLog]` to a property to force plaintext capture for that property, or pass
+`AuditPropertyPolicy.OnlyAttributedProperties` to the DI registration for a strict mode that captures only
+explicitly `[AuditLog]`-marked properties.
+
 ## Where it fits
 
 Audit logging is independent of the other interceptor-based concerns —

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -4,3 +4,6 @@
   Created 25 articles plus `index.md`, `log.md`, and `CLAUDE.md` covering
   architecture, core utilities, EF Core persistence, ASP.NET Core, service adapters,
   infrastructure/messaging, and testing.
+- **2026-08-04** — Updated `audit-logs.md` for SEC-005: documented default sensitive-property
+  redaction, the `[AuditLog]` per-property override, and the `AuditPropertyPolicy.OnlyAttributedProperties`
+  strict mode.

--- a/src/EfCore/DKNet.EfCore.Abstractions/Attributes/AuditLogAttribute.cs
+++ b/src/EfCore/DKNet.EfCore.Abstractions/Attributes/AuditLogAttribute.cs
@@ -1,11 +1,16 @@
 namespace DKNet.EfCore.Abstractions.Attributes;
 
 /// <summary>
-///     Include the Entities to the Audit Log.
+///     Include the Entities or properties to the Audit Log.
 ///     When this attribute is applied to an entity class, changes made to instances of that class
 ///     will be recorded in the audit logs, provided that the entity implements the necessary
 ///     auditing interfaces (e.g., IAuditedProperties). This attribute is useful for explicitly marking entities
 ///     that should be tracked for auditing purposes.
+///     When applied to a property instead, it has a second, independent meaning: under the default
+///     property policy (<c>AuditPropertyPolicy.RedactSensitive</c>) it forces plaintext capture of that
+///     property even if its name matches the sensitive-data pattern list; under the strict
+///     <c>AuditPropertyPolicy.OnlyAttributedProperties</c> policy it marks the property as allow-listed
+///     for capture at all.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, Inherited = false)]
 public sealed class AuditLogAttribute : Attribute;

--- a/src/EfCore/DKNet.EfCore.AuditLogs/AuditLogExtensions.cs
+++ b/src/EfCore/DKNet.EfCore.AuditLogs/AuditLogExtensions.cs
@@ -1,5 +1,6 @@
 using DKNet.EfCore.Abstractions.Attributes;
 using DKNet.EfCore.Abstractions.Entities;
+using DKNet.EfCore.AuditLogs.Internals;
 using DKNet.Fw.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -13,7 +14,8 @@ internal static class AuditLogExtensions
     public static AuditLogEntry? BuildAuditLog(
         this EntityEntry entry,
         EntityState originalState,
-        AuditLogBehaviour behaviour)
+        AuditLogBehaviour behaviour,
+        AuditPropertyPolicy propertyPolicy)
     {
         // If behaviour is OnlyAttributedAuditedEntities, skip entities not marked with AuditLogAttribute
         if (entry.Entity is not IAuditedProperties audited)
@@ -50,6 +52,14 @@ internal static class AuditLogExtensions
                     continue;
                 }
 
+                var isAttributed = clrProp.HasAttribute<AuditLogAttribute>();
+                if (propertyPolicy == AuditPropertyPolicy.OnlyAttributedProperties && !isAttributed)
+                {
+                    continue;
+                }
+
+                var isSensitive = !isAttributed && SensitiveDataPatterns.IsSensitive(clrProp);
+
                 var name = prop.Metadata.Name;
                 var oldVal = prop.OriginalValue;
                 var newVal = prop.CurrentValue;
@@ -60,7 +70,7 @@ internal static class AuditLogExtensions
                         new AuditFieldChange
                         {
                             FieldName = name,
-                            OldValue = oldVal,
+                            OldValue = isSensitive ? SensitiveDataPatterns.RedactedValue : oldVal,
                             NewValue = null
                         });
                     continue;
@@ -72,8 +82,8 @@ internal static class AuditLogExtensions
                         new AuditFieldChange
                         {
                             FieldName = name,
-                            OldValue = oldVal,
-                            NewValue = newVal
+                            OldValue = isSensitive ? SensitiveDataPatterns.RedactedValue : oldVal,
+                            NewValue = isSensitive ? SensitiveDataPatterns.RedactedValue : newVal
                         });
                 }
             }

--- a/src/EfCore/DKNet.EfCore.AuditLogs/EfCoreAuditLogSetup.cs
+++ b/src/EfCore/DKNet.EfCore.AuditLogs/EfCoreAuditLogSetup.cs
@@ -33,6 +33,25 @@ public enum AuditLogBehaviour
 }
 
 /// <summary>
+///     Controls how individual property values are captured within an audited entity's changes.
+/// </summary>
+public enum AuditPropertyPolicy
+{
+    /// <summary>
+    ///     Every non-ignored property is captured, but properties matching a known sensitive-data
+    ///     pattern have their old/new values replaced with a redacted sentinel, unless the property
+    ///     is explicitly marked with <see cref="AuditLogAttribute" />.
+    /// </summary>
+    RedactSensitive,
+
+    /// <summary>
+    ///     Only properties explicitly marked with <see cref="AuditLogAttribute" /> are captured;
+    ///     all other properties are omitted from the recorded changes entirely.
+    /// </summary>
+    OnlyAttributedProperties
+}
+
+/// <summary>
 ///     Internal options used to configure audit logging behaviour.
 /// </summary>
 internal sealed class AuditLogOptions
@@ -43,6 +62,11 @@ internal sealed class AuditLogOptions
     ///     Selected behaviour for which entities should be audit-logged.
     /// </summary>
     public required AuditLogBehaviour Behaviour { get; init; }
+
+    /// <summary>
+    ///     Selected policy for how individual property values are captured.
+    /// </summary>
+    public AuditPropertyPolicy PropertyPolicy { get; init; } = AuditPropertyPolicy.RedactSensitive;
 
     #endregion
 }
@@ -75,12 +99,18 @@ public static class EfCoreAuditLogSetup
         /// </summary>
         /// <typeparam name="TDbContext">The application's DbContext type the hook will attach to.</typeparam>
         /// <param name="behaviour">Optional behaviour that controls which entities are included in audit logs.</param>
+        /// <param name="propertyPolicy">Optional policy that controls how individual property values are captured.</param>
         /// <returns>The updated <see cref="IServiceCollection" /> for chaining.</returns>
         public IServiceCollection AddEfCoreAuditHook<TDbContext>(
-            AuditLogBehaviour behaviour = AuditLogBehaviour.IncludeAllAuditedEntities)
+            AuditLogBehaviour behaviour = AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy propertyPolicy = AuditPropertyPolicy.RedactSensitive)
             where TDbContext : DbContext =>
             services
-                .AddSingleton(Options.Create(new AuditLogOptions { Behaviour = behaviour }))
+                .AddSingleton(Options.Create(new AuditLogOptions
+                {
+                    Behaviour = behaviour,
+                    PropertyPolicy = propertyPolicy
+                }))
                 .AddHook<TDbContext, EfCoreAuditHook>();
 
         /// <summary>
@@ -91,9 +121,11 @@ public static class EfCoreAuditLogSetup
         /// <typeparam name="TDbContext">The application's DbContext type.</typeparam>
         /// <typeparam name="TPublisher">The publisher implementation to register for the DbContext type.</typeparam>
         /// <param name="behaviour">Optional behaviour that controls which entities are included in audit logs.</param>
+        /// <param name="propertyPolicy">Optional policy that controls how individual property values are captured.</param>
         /// <returns>The updated <see cref="IServiceCollection" /> for chaining.</returns>
         public IServiceCollection AddEfCoreAuditLogs<TDbContext, TPublisher>(
-            AuditLogBehaviour behaviour = AuditLogBehaviour.IncludeAllAuditedEntities)
+            AuditLogBehaviour behaviour = AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy propertyPolicy = AuditPropertyPolicy.RedactSensitive)
             where TDbContext : DbContext
             where TPublisher : class, IAuditLogPublisher
         {
@@ -104,7 +136,7 @@ public static class EfCoreAuditLogSetup
                 return services;
 
             services.AddKeyedScoped<IAuditLogPublisher, TPublisher>(key);
-            services.AddEfCoreAuditHook<TDbContext>(behaviour);
+            services.AddEfCoreAuditHook<TDbContext>(behaviour, propertyPolicy);
             return services;
         }
     }

--- a/src/EfCore/DKNet.EfCore.AuditLogs/Internals/EfCoreAuditHook.cs
+++ b/src/EfCore/DKNet.EfCore.AuditLogs/Internals/EfCoreAuditHook.cs
@@ -35,7 +35,7 @@ internal sealed class EfCoreAuditHook(
     {
         var logs = context.Entities
             .Where(e => e.OriginalState is EntityState.Added or EntityState.Modified or EntityState.Deleted)
-            .Select(e => e.Entry.BuildAuditLog(e.OriginalState, option.Value.Behaviour))
+            .Select(e => e.Entry.BuildAuditLog(e.OriginalState, option.Value.Behaviour, option.Value.PropertyPolicy))
             .Where(l => l is not null)
             .OfType<AuditLogEntry>()
             .ToList();

--- a/src/EfCore/DKNet.EfCore.AuditLogs/Internals/SensitiveDataPatterns.cs
+++ b/src/EfCore/DKNet.EfCore.AuditLogs/Internals/SensitiveDataPatterns.cs
@@ -1,0 +1,66 @@
+// Copyright (c) https://drunkcoding.net. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// Author: DRUNK Coding Team
+// File: SensitiveDataPatterns.cs
+// Description: Hardcoded deny-list used to detect audited properties that likely carry sensitive data.
+
+using System.Reflection;
+
+namespace DKNet.EfCore.AuditLogs.Internals;
+
+/// <summary>
+///     Detects properties that are likely to carry sensitive data, so their values can be redacted
+///     by default in audit logs (see <see cref="AuditPropertyPolicy.RedactSensitive" />).
+/// </summary>
+internal static class SensitiveDataPatterns
+{
+    #region Fields
+
+    private static readonly string[] _nameFragments =
+    [
+        "password",
+        "secret",
+        "token",
+        "apikey",
+        "api_key",
+        "ssn",
+        "socialsecuritynumber",
+        "creditcard",
+        "cvv",
+        "pin",
+        "connectionstring",
+        "privatekey",
+        "passphrase",
+        "accesskey",
+        "salt"
+    ];
+
+    #endregion
+
+    #region Properties
+
+    /// <summary>
+    ///     The sentinel value substituted for the real value of a redacted property.
+    /// </summary>
+    public const string RedactedValue = "***REDACTED***";
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    ///     Determines whether the given property is considered sensitive by name or CLR type.
+    /// </summary>
+    /// <param name="property">The property to inspect.</param>
+    /// <returns><c>true</c> if the property's name or type matches a known sensitive pattern.</returns>
+    public static bool IsSensitive(PropertyInfo? property)
+    {
+        if (property is null) return false;
+
+        if (property.PropertyType == typeof(System.Security.SecureString)) return true;
+
+        return _nameFragments.Any(f => property.Name.Contains(f, StringComparison.OrdinalIgnoreCase));
+    }
+
+    #endregion
+}

--- a/src/EfCore/DKNet.EfCore.AuditLogs/README.md
+++ b/src/EfCore/DKNet.EfCore.AuditLogs/README.md
@@ -164,10 +164,32 @@ public static class AuditLogExtensions
 
 ## Extending
 
-### Filter Properties
+### Sensitive Property Redaction
 
-Wrap or fork `BuildAuditLog` (internal extension) to exclude sensitive fields (like passwords, secrets). Provide a
-custom hook variant if needed.
+By default (`AuditPropertyPolicy.RedactSensitive`) any property whose name matches a known sensitive pattern
+(`password`, `secret`, `token`, `apikey`, `ssn`, `creditcard`, `cvv`, `pin`, `connectionstring`, `privatekey`,
+`passphrase`, `accesskey`, `salt`, etc., or a `SecureString` type) has its `OldValue`/`NewValue` replaced with
+`"***REDACTED***"` instead of being captured in plaintext. The field still appears in `Changes` so you can see that
+it changed — just not its value.
+
+Apply `[AuditLog]` directly to a property to force plaintext capture of that property, overriding redaction:
+
+```csharp
+public sealed class ApiClient : AuditedEntity<Guid>
+{
+    [AuditLog] // captured in plaintext even though the name matches "token"
+    public DateTimeOffset TokenExpiryUtc { get; set; }
+}
+```
+
+For a strict allow-list instead, pass `AuditPropertyPolicy.OnlyAttributedProperties` to `AddEfCoreAuditHook` /
+`AddEfCoreAuditLogs` — only properties explicitly marked `[AuditLog]` are captured; every other property is omitted
+from `Changes` entirely:
+
+```csharp
+services.AddEfCoreAuditLogs<MyDbContext, ConsoleAuditPublisher>(
+    propertyPolicy: AuditPropertyPolicy.OnlyAttributedProperties);
+```
 
 ### Enrich Audit Logs
 

--- a/src/EfCore/EfCore.AuditLogs.Tests/AdditionalAuditLogEdgeCasesTests.cs
+++ b/src/EfCore/EfCore.AuditLogs.Tests/AdditionalAuditLogEdgeCasesTests.cs
@@ -21,7 +21,8 @@ public class AdditionalAuditLogEdgeCasesTests
         ctx.Remove(e);
         ctx.ChangeTracker.DetectChanges();
         var entry = ctx.Entry(e);
-        var log = entry.BuildAuditLog(EntityState.Deleted, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Deleted, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
         log.Changes.Count.ShouldBeGreaterThan(0); // Should contain all mapped properties
         log.Changes.All(c => c.NewValue == null).ShouldBeTrue();
     }
@@ -42,7 +43,8 @@ public class AdditionalAuditLogEdgeCasesTests
         // Ensure none of the properties marked modified
         foreach (var p in entry.Properties) p.IsModified = false;
 
-        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
         log.Changes.ShouldBeEmpty();
     }
 
@@ -59,7 +61,8 @@ public class AdditionalAuditLogEdgeCasesTests
         e.UpdateProfile("updater");
         ctx.ChangeTracker.DetectChanges();
         var entry = ctx.Entry(e);
-        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
         log.Changes.ShouldNotContain(c => c.FieldName == nameof(TestAuditEntity.Notes));
     }
 
@@ -75,7 +78,8 @@ public class AdditionalAuditLogEdgeCasesTests
         // Mark property as modified without changing its value
         var entry = ctx.Entry(e);
         entry.Property(nameof(TestAuditEntity.Age)).IsModified = true; // value remains 7
-        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
         log.Changes.ShouldContain(c =>
             c.FieldName == nameof(TestAuditEntity.Age) && (int?)c.OldValue == 7 && (int?)c.NewValue == 7);
     }
@@ -95,7 +99,8 @@ public class AdditionalAuditLogEdgeCasesTests
         // Removed ctx.Update(e) to allow EF Core to track only changed audit fields
         ctx.ChangeTracker.DetectChanges();
         var entry = ctx.Entry(e);
-        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
 
         // Age, Name, Balance, IsActive unchanged -> changes should only include audit fields UpdatedBy / UpdatedOn if tracked
         log.Changes.ShouldContain(c => c.FieldName == nameof(TestAuditEntity.UpdatedBy));
@@ -117,7 +122,8 @@ public class AdditionalAuditLogEdgeCasesTests
         ctx.Update(e);
         ctx.ChangeTracker.DetectChanges();
         var entry = ctx.Entry(e);
-        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
         log.Changes.ShouldContain(c =>
             c.FieldName == nameof(TestAuditEntity.Notes) && (string?)c.OldValue == "original" && c.NewValue == null);
     }

--- a/src/EfCore/EfCore.AuditLogs.Tests/AdditionalAuditLogTests.cs
+++ b/src/EfCore/EfCore.AuditLogs.Tests/AdditionalAuditLogTests.cs
@@ -78,7 +78,8 @@ public class AdditionalAuditLogTests
         ctx.Update(e);
         ctx.ChangeTracker.DetectChanges();
         var entry = ctx.Entry(e);
-        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
         log.Changes.ShouldContain(c =>
             c.FieldName == nameof(TestAuditEntity.Notes) && c.OldValue == null && (string?)c.NewValue == "note");
         log.Changes.ShouldContain(c =>
@@ -97,7 +98,8 @@ public class AdditionalAuditLogTests
         ctx.Remove(e);
         ctx.ChangeTracker.DetectChanges();
         var entry = ctx.Entry(e);
-        var log = entry.BuildAuditLog(EntityState.Deleted, AuditLogBehaviour.IncludeAllAuditedEntities)!;
+        var log = entry.BuildAuditLog(EntityState.Deleted, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive)!;
         log.Changes.ShouldAllBe(c => c.NewValue == null);
         log.EntityName.ShouldBe(nameof(TestAuditEntity));
     }
@@ -113,7 +115,8 @@ public class AdditionalAuditLogTests
         ctx.ChangeTracker.DetectChanges();
         var entry = ctx.Entry(plain);
         entry.State = EntityState.Modified;
-        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities);
+        var log = entry.BuildAuditLog(EntityState.Modified, AuditLogBehaviour.IncludeAllAuditedEntities,
+            AuditPropertyPolicy.RedactSensitive);
         log.ShouldBeNull();
     }
 

--- a/src/EfCore/EfCore.AuditLogs.Tests/SensitivePropertyRedactionTests.cs
+++ b/src/EfCore/EfCore.AuditLogs.Tests/SensitivePropertyRedactionTests.cs
@@ -1,0 +1,196 @@
+// New tests to cover AuditPropertyPolicy redaction / strict-mode paths (SEC-005).
+
+using System.Collections.Concurrent;
+using DKNet.EfCore.Abstractions.Attributes;
+using DKNet.EfCore.Abstractions.Entities;
+using DKNet.EfCore.AuditLogs;
+using DKNet.EfCore.AuditLogs.Internals;
+using DKNet.EfCore.Hooks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace EfCore.AuditLogs.Tests;
+
+internal sealed class SensitiveAuditEntity : AuditedEntity<Guid>
+{
+    #region Properties
+
+    // Sensitive by name, no attribute -> redacted under RedactSensitive, omitted under OnlyAttributedProperties.
+    public string Password { get; set; } = string.Empty;
+
+    // Sensitive by name but explicitly attributed -> always captured in plaintext.
+    [AuditLog] public DateTimeOffset TokenExpiryUtc { get; set; }
+
+    // Non-sensitive, no attribute -> plaintext under RedactSensitive, omitted under OnlyAttributedProperties.
+    public string DisplayName { get; set; } = string.Empty;
+
+    #endregion
+
+    #region Methods
+
+    public void SetCreatedOn(string byUser, DateTimeOffset? on = null) => SetCreatedBy(byUser, on);
+    public void SetUpdatedOn(string byUser, DateTimeOffset? on = null) => SetUpdatedBy(byUser, on);
+
+    #endregion
+}
+
+internal sealed class SensitiveAuditDbContext(DbContextOptions<SensitiveAuditDbContext> options) : DbContext(options)
+{
+    #region Properties
+
+    public DbSet<SensitiveAuditEntity> SensitiveEntities => Set<SensitiveAuditEntity>();
+
+    #endregion
+}
+
+internal sealed class SensitiveCapturingPublisher : IAuditLogPublisher
+{
+    #region Fields
+
+    private static readonly ConcurrentBag<AuditLogEntry> _logs = [];
+
+    #endregion
+
+    #region Properties
+
+    public static IReadOnlyCollection<AuditLogEntry> Logs => _logs;
+
+    #endregion
+
+    #region Methods
+
+    public static void Clear()
+    {
+        while (_logs.TryTake(out _))
+        {
+        }
+    }
+
+    public Task PublishAsync(IEnumerable<AuditLogEntry> logs, CancellationToken cancellationToken = default)
+    {
+        foreach (var l in logs) _logs.Add(l);
+
+        return Task.CompletedTask;
+    }
+
+    #endregion
+}
+
+public class SensitivePropertyRedactionTests
+{
+    #region Methods
+
+    private static ServiceProvider BuildProvider(AuditPropertyPolicy propertyPolicy, string dbPath)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddEfCoreAuditLogs<SensitiveAuditDbContext, SensitiveCapturingPublisher>(
+            propertyPolicy: propertyPolicy);
+        services.AddDbContextWithHook<SensitiveAuditDbContext>((_, o) =>
+        {
+            o.UseSqlite($"Data Source={dbPath}");
+            o.EnableSensitiveDataLogging();
+        });
+        return services.BuildServiceProvider();
+    }
+
+    private static string NewDbPath() => Path.Combine(Path.GetTempPath(), $"sensitive_{Guid.NewGuid():N}.db");
+
+    private static async Task<(ServiceProvider provider, Guid id)> SeedAndUpdateAsync(AuditPropertyPolicy policy)
+    {
+        var db = NewDbPath();
+        var provider = BuildProvider(policy, db);
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<SensitiveAuditDbContext>();
+            await ctx.Database.EnsureCreatedAsync();
+        }
+
+        Guid id;
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<SensitiveAuditDbContext>();
+            var e = new SensitiveAuditEntity
+            {
+                Password = "hunter2",
+                TokenExpiryUtc = DateTimeOffset.UtcNow,
+                DisplayName = "Alice"
+            };
+            e.SetCreatedOn("creator");
+            ctx.Add(e);
+            await ctx.SaveChangesAsync();
+            id = e.Id;
+        }
+
+        SensitiveCapturingPublisher.Clear();
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var ctx = scope.ServiceProvider.GetRequiredService<SensitiveAuditDbContext>();
+            var e = await ctx.SensitiveEntities.FirstAsync(x => x.Id == id);
+            e.Password = "hunter3";
+            e.TokenExpiryUtc = e.TokenExpiryUtc.AddHours(1);
+            e.DisplayName = "Alice B.";
+            e.SetUpdatedOn("updater");
+            await ctx.SaveChangesAsync();
+        }
+
+        await Task.Delay(1000);
+        return (provider, id);
+    }
+
+    [Fact]
+    public async Task RedactSensitive_UnannotatedSensitiveProperty_IsRedacted()
+    {
+        var (provider, _) = await SeedAndUpdateAsync(AuditPropertyPolicy.RedactSensitive);
+        await using var _ = provider;
+
+        var log = SensitiveCapturingPublisher.Logs.Single(l =>
+            l.EntityName == nameof(SensitiveAuditEntity) && l.Action == AuditLogAction.Updated);
+        var change = log.Changes.Single(c => c.FieldName == nameof(SensitiveAuditEntity.Password));
+        change.OldValue.ShouldBe(SensitiveDataPatterns.RedactedValue);
+        change.NewValue.ShouldBe(SensitiveDataPatterns.RedactedValue);
+    }
+
+    [Fact]
+    public async Task RedactSensitive_AttributedSensitiveProperty_CapturedInPlaintext()
+    {
+        var (provider, _) = await SeedAndUpdateAsync(AuditPropertyPolicy.RedactSensitive);
+        await using var _ = provider;
+
+        var log = SensitiveCapturingPublisher.Logs.Single(l =>
+            l.EntityName == nameof(SensitiveAuditEntity) && l.Action == AuditLogAction.Updated);
+        var change = log.Changes.Single(c => c.FieldName == nameof(SensitiveAuditEntity.TokenExpiryUtc));
+        change.OldValue.ShouldNotBe(SensitiveDataPatterns.RedactedValue);
+        change.NewValue.ShouldNotBe(SensitiveDataPatterns.RedactedValue);
+    }
+
+    [Fact]
+    public async Task RedactSensitive_NonSensitiveProperty_CapturedInPlaintext()
+    {
+        var (provider, _) = await SeedAndUpdateAsync(AuditPropertyPolicy.RedactSensitive);
+        await using var _ = provider;
+
+        var log = SensitiveCapturingPublisher.Logs.Single(l =>
+            l.EntityName == nameof(SensitiveAuditEntity) && l.Action == AuditLogAction.Updated);
+        var change = log.Changes.Single(c => c.FieldName == nameof(SensitiveAuditEntity.DisplayName));
+        change.OldValue.ShouldBe("Alice");
+        change.NewValue.ShouldBe("Alice B.");
+    }
+
+    [Fact]
+    public async Task OnlyAttributedProperties_CapturesOnlyAttributedProperty()
+    {
+        var (provider, _) = await SeedAndUpdateAsync(AuditPropertyPolicy.OnlyAttributedProperties);
+        await using var _ = provider;
+
+        var log = SensitiveCapturingPublisher.Logs.Single(l =>
+            l.EntityName == nameof(SensitiveAuditEntity) && l.Action == AuditLogAction.Updated);
+        log.Changes.ShouldContain(c => c.FieldName == nameof(SensitiveAuditEntity.TokenExpiryUtc));
+        log.Changes.ShouldNotContain(c => c.FieldName == nameof(SensitiveAuditEntity.Password));
+        log.Changes.ShouldNotContain(c => c.FieldName == nameof(SensitiveAuditEntity.DisplayName));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## What

SEC-005 (architecture-review finding, high severity): `AuditLogExtensions.BuildAuditLog` captured every changed property's plaintext value by default, relying on an opt-out `[IgnoreAuditLog]` attribute per sensitive field. Any sensitive field added to an audited entity leaked into audit sinks by default with no redaction.

## Fix — hybrid policy, confirmed with product-owner

1. **Default (non-breaking):** properties matched by a central sensitive name/type pattern list (`SensitiveDataPatterns`) are redacted — value replaced with a fixed sentinel, the change is still recorded, the value isn't.
2. **Per-property override:** `[AuditLog]` (now also valid on properties, previously class-only) forces plaintext capture of a specific property even if it matches the sensitive pattern list.
3. **Opt-in strict mode:** new `AuditPropertyPolicy.OnlyAttributedProperties`, passed to `AddEfCoreAuditHook<TDbContext>`/`AddEfCoreAuditLogs<TDbContext,TPublisher>`, captures only properties explicitly marked `[AuditLog]`.

Existing `[IgnoreAuditLog]` opt-out behaviour and the entity-level `AuditLogBehaviour` are unchanged.

## Testing / coverage

- New `SensitivePropertyRedactionTests.cs` covers all 4 new Gherkin scenarios (default redaction, override, strict mode, non-sensitive plaintext capture); existing `IgnoreAuditLog` coverage untouched.
- Full pre-existing `EfCore.AuditLogs.Tests` suite green (a few pre-existing `Task.Delay`-based timing flakes confirmed present on the base commit too, unrelated to this change).
- Coverage ≥80% on every touched class: `AuditLogAttribute`, `AuditLogExtensions`, `EfCoreAuditLogSetup`, `EfCoreAuditHook`, `SensitiveDataPatterns` (all well above threshold).
- `dotnet build` clean, zero warnings. `dotnet pack` clean.

## Breaking changes

None for current consumers under the default policy — this is intentionally the non-breaking half of the fix. The fully fail-safe posture (`OnlyAttributedProperties`) is opt-in, not the default; making it the default was evaluated and deliberately deferred (see DRK-80) as a separate, major-version-worthy breaking change.

Ref: DRK-80
