### PR TITLE
[DRK-79] Stop IRsaEncryption resolving to a throwaway per-resolution key

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved documentation organization and navigation
 - Enhanced main README.md to be more concise and point to docs/
+- **Breaking:** `AddEncryptionServices()` no longer registers `IRsaEncryption` — it previously resolved to a new,
+  throwaway random key pair on every DI resolution, so keys never survived across resolutions. Callers that need
+  RSA must opt in explicitly with `services.AddRsaEncryption(privateKeyBase64)`, which registers `IRsaEncryption`
+  as a singleton built from a caller-supplied key.
+
+### Security
+- Fixed `IRsaEncryption` resolving to an unmanaged, silently discarded random key pair per resolution
+  (DKNet.Svc.Encryption).
 
 ## [2024.12.0] - 2024-12-XX
 

--- a/src/Services/DKNet.Svc.Encryption/EncryptionSetup.cs
+++ b/src/Services/DKNet.Svc.Encryption/EncryptionSetup.cs
@@ -18,11 +18,30 @@ public static class EncryptionSetup
 #pragma warning disable CS0618
         services.AddTransient<IAesEncryption, AesEncryption>();
 #pragma warning restore CS0618
-        services.AddTransient<IRsaEncryption, RsaEncryption>(_ => new RsaEncryption());
         services.AddTransient<IShaHashing, ShaHashing>();
         services.AddTransient<IHmacHashing, HmacHashing>();
 
         services.AddTransient<IAesGcmEncryption, AesGcmEncryption>();
+        return services;
+    }
+
+    /// <summary>
+    ///     Registers <see cref="IRsaEncryption" /> as a singleton constructed from the supplied Base64 encoded
+    ///     PKCS#1 private key. The same instance (and therefore the same key) is returned for every resolution,
+    ///     so data encrypted/signed via one resolution can be decrypted/verified via another.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="privateKeyBase64">
+    ///     The Base64 encoded PKCS#1 private key. Source this from configuration or a key vault — never hardcode it.
+    /// </param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <exception cref="ArgumentException">
+    ///     Thrown when <paramref name="privateKeyBase64" /> is null, empty, or whitespace.
+    /// </exception>
+    public static IServiceCollection AddRsaEncryption(this IServiceCollection services, string privateKeyBase64)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(privateKeyBase64);
+        services.AddSingleton<IRsaEncryption>(_ => new RsaEncryption(privateKeyBase64));
         return services;
     }
 

--- a/src/Services/DKNet.Svc.Encryption/README.md
+++ b/src/Services/DKNet.Svc.Encryption/README.md
@@ -191,10 +191,17 @@ Resolves:
 - `IShaHashing`
 - `IHmacHashing`
 - `IPasswordAesEncryption`
-- `IRsaEncryption` (generated keypair per singleton instance – for multi-key scenarios register factories yourself)
 
-> Registering `IRsaEncryption` as singleton generates one key pair at startup. Override if per-tenant / per-request keys
-> are needed.
+`IRsaEncryption` is not registered by `AddEncryptionServices()` — RSA needs a caller-supplied key, so it has its own
+opt-in extension:
+
+```csharp
+services.AddRsaEncryption(privateKeyBase64);
+```
+
+This registers `IRsaEncryption` as a **singleton** built from the Base64 encoded PKCS#1 private key you provide
+(source it from configuration or a key vault — never hardcode it). The same instance is returned for every
+resolution, so data encrypted/signed via one resolution can be decrypted/verified via another.
 
 ---
 

--- a/src/Services/Svc.Encryption.Tests/EdgeCaseTests.cs
+++ b/src/Services/Svc.Encryption.Tests/EdgeCaseTests.cs
@@ -96,7 +96,48 @@ public class EdgeCaseTests
         provider.GetRequiredService<IHmacHashing>().ShouldNotBeNull();
 
         //provider.GetRequiredService<IPasswordAesEncryption>().ShouldNotBeNull();
-        provider.GetRequiredService<IRsaEncryption>().ShouldNotBeNull();
+        provider.GetService<IRsaEncryption>().ShouldBeNull();
+    }
+
+    [Fact]
+    public void AddRsaEncryption_Registers_Singleton()
+    {
+        var privateKey = new RsaEncryption().PrivateKey;
+
+        var services = new ServiceCollection();
+        services.AddRsaEncryption(privateKey!);
+        var provider = services.BuildServiceProvider();
+
+        var first = provider.GetRequiredService<IRsaEncryption>();
+        var second = provider.GetRequiredService<IRsaEncryption>();
+
+        ReferenceEquals(first, second).ShouldBeTrue();
+        first.PublicKey.ShouldBe(second.PublicKey);
+    }
+
+    [Fact]
+    public void AddRsaEncryption_TwoResolutions_RoundTrip()
+    {
+        var privateKey = new RsaEncryption().PrivateKey;
+
+        var services = new ServiceCollection();
+        services.AddRsaEncryption(privateKey!);
+        var provider = services.BuildServiceProvider();
+
+        var encryptor = provider.GetRequiredService<IRsaEncryption>();
+        var cipherText = encryptor.Encrypt("hello world");
+
+        var decryptor = provider.GetRequiredService<IRsaEncryption>();
+        decryptor.Decrypt(cipherText).ShouldBe("hello world");
+    }
+
+    [Theory]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void AddRsaEncryption_NullOrWhitespaceKey_Throws(string key)
+    {
+        var services = new ServiceCollection();
+        Should.Throw<ArgumentException>(() => services.AddRsaEncryption(key));
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

- `AddEncryptionServices()` no longer silently registers `IRsaEncryption` with a throwaway, per-resolution random key (was `AddTransient<IRsaEncryption, RsaEncryption>(_ => new RsaEncryption())` — every resolution got an unrelated key, so encrypt/sign in one place could never be decrypted/verified in another, and the key was discarded).
- New explicit opt-in `services.AddRsaEncryption(privateKeyBase64)` registers `IRsaEncryption` as a **singleton** built from a caller-supplied Base64 PKCS#1 private key — same key for every resolution within the process, so round-tripping across separate resolutions now works. The caller is responsible for sourcing the key (config/Key Vault/secret store).
- Updated `EdgeCaseTests.cs` DI coverage test to assert the old insecure default is gone, plus new tests for the singleton registration, cross-resolution round-trip, and rejection of a null/empty/whitespace key.
- Updated `README.md`'s DI section and `docs/CHANGELOG.md` to document the change.

**Breaking change**: any consumer calling only `AddEncryptionServices()` and resolving `IRsaEncryption` will now get an `InvalidOperationException` (no service registered) instead of a silently-generated throwaway key. Switch to `services.AddRsaEncryption(privateKeyBase64)`.

Security finding: `DKNet:SEC-007:src/Services/DKNet.Svc.Encryption/EncryptionSetup.cs:AddEncryptionServices`.

## Test plan

- [x] `dotnet build src/DKNet.FW.sln -c Debug` — 0 warnings, 0 errors
- [x] `dotnet test src/Services/Svc.Encryption.Tests` — 87/87 pass
- [x] Coverage ≥90% on touched files
- [x] `dotnet pack src/Services/DKNet.Svc.Encryption -c Release` — clean
