### PR TITLE
[DRK-76] Fix IdempotencyKeyEntity.SanitizeKey composite-key collision

### DIFF
--- a/src/AspNet/AspCore.Idempotency.MsSqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
+++ b/src/AspNet/AspCore.Idempotency.MsSqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="IdempotencyKeyEntityTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+namespace AspCore.Idempotency.MsSqlStore.Tests.Unit;
+
+/// <summary>
+///     Unit tests for <see cref="IdempotencyKeyEntity.SanitizeKey" />.
+/// </summary>
+public sealed class IdempotencyKeyEntityTests
+{
+    #region Methods
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
+    {
+        // Act
+        var act = () => IdempotencyKeyEntity.SanitizeKey(key!);
+
+        // Assert
+        Should.Throw<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    {
+        // Arrange
+        const string keyA = "POST:/ab:cd";
+        const string keyB = "POST:/a:bcd";
+
+        // Act
+        var sanitizedA = IdempotencyKeyEntity.SanitizeKey(keyA);
+        var sanitizedB = IdempotencyKeyEntity.SanitizeKey(keyB);
+
+        // Assert
+        sanitizedA.ShouldNotBe(sanitizedB);
+    }
+
+    [Fact]
+    public void SanitizeKey_SameInputTwice_IsDeterministicBoundedAndNonEmpty()
+    {
+        // Arrange
+        const string key = "GET:/api/orders:idem-key-123";
+
+        // Act
+        var first = IdempotencyKeyEntity.SanitizeKey(key);
+        var second = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        first.ShouldBe(second);
+        first.ShouldNotBeNullOrEmpty();
+        first.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    [Fact]
+    public void SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    {
+        // Arrange
+        string[] keys =
+        [
+            "GET:/a/b:x",
+            "GET:/a:b/x",
+            "GET:/ab:x"
+        ];
+
+        // Act
+        var sanitized = keys.Select(IdempotencyKeyEntity.SanitizeKey).ToArray();
+
+        // Assert
+        sanitized.Distinct().Count().ShouldBe(sanitized.Length);
+    }
+
+    [Fact]
+    public void SanitizeKey_VeryLongCompositeKey_HashesSuccessfully()
+    {
+        // Arrange
+        var key = $"{new string('M', 20)}:{new string('E', 250)}:{new string('K', 150)}";
+
+        // Act
+        var sanitized = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        sanitized.ShouldNotBeNullOrEmpty();
+        sanitized.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    #endregion
+}

--- a/src/AspNet/DKNet.AspCore.Idempotency.MsSqlStore/Data/IdempotencyKeyEntity.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency.MsSqlStore/Data/IdempotencyKeyEntity.cs
@@ -5,7 +5,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.RegularExpressions;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace DKNet.AspCore.Idempotency.MsSqlStore.Data;
 
@@ -101,25 +102,18 @@ internal sealed class IdempotencyKeyEntity
     #region Methods
 
     /// <summary>
-    ///     Sanitizes an idempotency key for use as a database key.
-    ///     Removes invalid characters to prevent injection attacks.
+    ///     Sanitizes an idempotency key for use as a database key by hashing it.
+    ///     Hashing (rather than stripping characters) guarantees structurally distinct
+    ///     composite keys never collapse onto the same database key.
     /// </summary>
     /// <param name="key">The idempotency key to sanitize.</param>
-    /// <returns>A sanitized key with only alphanumeric characters and hyphens.</returns>
+    /// <returns>A deterministic, fixed-length (64-character) uppercase hex SHA-256 hash of the key.</returns>
     internal static string SanitizeKey(string key)
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
 
-        // Remove non-alphanumeric characters except hyphens
-        var sanitized = Regex.Replace(key, @"[^a-zA-Z0-9\-]", string.Empty);
-
-        if (string.IsNullOrEmpty(sanitized))
-            throw new ArgumentException("Idempotency key contains no valid characters.", nameof(key));
-
-        if (sanitized.Length > 128) sanitized = sanitized[..128];
-
-        return sanitized.ToUpperInvariant();
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key)));
     }
 
     #endregion

--- a/src/EfCore/EfCore.AuditLogs.Tests/AuditLogBehaviourTests.cs
+++ b/src/EfCore/EfCore.AuditLogs.Tests/AuditLogBehaviourTests.cs
@@ -138,6 +138,8 @@ public class AuditLogBehaviourTests
             unattributedId = u.Id;
         }
 
+        await Task.Delay(1000);
+
         BehaviourCapturingPublisher.Logs.Count.ShouldBeGreaterThan(0);
         BehaviourCapturingPublisher.Clear();
 
@@ -192,6 +194,8 @@ public class AuditLogBehaviourTests
             unattributedId = u.Id;
         }
 
+        await Task.Delay(1000);
+
         // Ensure still no logs
         BehaviourCapturingPublisher.Logs.Count.ShouldBe(1);
         BehaviourCapturingPublisher.Clear();
@@ -242,6 +246,8 @@ public class AuditLogBehaviourTests
             unattributedId = u.Id;
             attributedId = a.Id;
         }
+
+        await Task.Delay(1000);
 
         BehaviourCapturingPublisher.Logs.Count.ShouldBeLessThanOrEqualTo(1);
         BehaviourCapturingPublisher.Clear();


### PR DESCRIPTION
## Problem

`IdempotencyKeyEntity.SanitizeKey` stripped every character that wasn't alphanumeric or a hyphen, including the `:` and `/` delimiters separating the composite key's segments (`Method:Endpoint:IdempotentKey`). Distinct composite keys could collapse to the same sanitized string — and since that string backs the `UX_CompositeKey` unique DB index, one request's cached response could be served to an entirely unrelated request.

Example from the finding: `"POST:/ab:cd"` and `"POST:/a:bcd"` both sanitized to `"POSTABCD"`.

## Fix

`SanitizeKey` now hashes the full composite key with SHA-256 (`Convert.ToHexString(SHA256.HashData(...))`) instead of stripping characters — fixed-length (64 hex chars, well under the 128-char DB column), collision-resistant, deterministic. Null/empty/whitespace input still throws `ArgumentException` as before.

Also includes an unrelated pre-existing flaky-test fix surfaced during verification: `AuditLogBehaviourTests` asserted on a fire-and-forget audit publish (`Task.Run`, never awaited) with no wait, racing the background write. Added the same delay pattern already used by the file's own `Update` test blocks.

## Testing

- New `IdempotencyKeyEntityTests` cover: the exact collision from the finding, null/empty/whitespace rejection, determinism/bounded length, and a set of delimiter-shifted keys asserted pairwise distinct.
- `EfCore.AuditLogs.Tests` (previously flaky) — 31/31 green across repeated runs.
- `dotnet build DKNet.FW.sln -c Debug` — 0 warnings, 0 errors.
- `dotnet pack` clean for `DKNet.AspCore.Idempotency.MsSqlStore`.

Related finding: `IDEM-KEY-001` (DRK-76).