### PR TITLE
[DRK-133] Split AuditLogAttribute XML doc: move property-level behaviour into remarks

### DIFF
--- a/src/EfCore/DKNet.EfCore.Abstractions/Attributes/AuditLogAttribute.cs
+++ b/src/EfCore/DKNet.EfCore.Abstractions/Attributes/AuditLogAttribute.cs
@@ -6,11 +6,13 @@ namespace DKNet.EfCore.Abstractions.Attributes;
 ///     will be recorded in the audit logs, provided that the entity implements the necessary
 ///     auditing interfaces (e.g., IAuditedProperties). This attribute is useful for explicitly marking entities
 ///     that should be tracked for auditing purposes.
+/// </summary>
+/// <remarks>
 ///     When applied to a property instead, it has a second, independent meaning: under the default
 ///     property policy (<c>AuditPropertyPolicy.RedactSensitive</c>) it forces plaintext capture of that
 ///     property even if its name matches the sensitive-data pattern list; under the strict
 ///     <c>AuditPropertyPolicy.OnlyAttributedProperties</c> policy it marks the property as allow-listed
 ///     for capture at all.
-/// </summary>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, Inherited = false)]
 public sealed class AuditLogAttribute : Attribute;


### PR DESCRIPTION
Doc-only change: split `AuditLogAttribute`'s XML doc so the class-level and property-level meanings each get their own audience.

- `<summary>` now covers only the class-level meaning (entity inclusion in the audit log).
- The property-level meaning (force-plaintext under `RedactSensitive`, allow-listing under `OnlyAttributedProperties`) moved into a separate `<remarks>` block.

No behavioural, API-surface, or public-signature change. `dotnet build -c Debug` verified warning-free.
