### PR TITLE
[DRK-145] Fix idempotency SanitizeKey collisions in NpgsqlStore and DistributedCacheStore

### DIFF
--- a/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
+++ b/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
@@ -1,0 +1,179 @@
+using DKNet.AspCore.Idempotency;
+using DKNet.AspCore.Idempotency.Store;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AspCore.Idempotency.NpgsqlStore.Tests.Unit;
+
+/// <summary>
+///     Tests for idempotency store edge cases not covered
+///     by the main repository tests, specifically for NpgsqlStore's SanitizeKey implementation.
+/// </summary>
+public class IdempotencyNpgsqlStoreTests
+{
+    #region Fields
+
+    private readonly IDistributedCache _cache;
+    private readonly ILogger<IdempotencyNpgsqlStoreTests> _logger;
+
+    #endregion
+
+    #region Constructors
+
+    public IdempotencyNpgsqlStoreTests()
+    {
+        _cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        _logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<IdempotencyNpgsqlStoreTests>();
+    }
+
+    #endregion
+
+    #region Methods
+
+    private IIdempotencyKeyStore CreateDistributedCacheStore(IdempotencyOptions? options = null) =>
+        new IdempotencyDistributedCacheStore(_cache, Options.Create(options ?? new IdempotencyOptions()), _logger);
+
+    private static IdempotentKeyInfo MakeKey(string key) =>
+        new() { IdempotentKey = key, Endpoint = "/api/test", Method = "POST" };
+
+    [Fact]
+    public async Task DistributedCache_SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    {
+        // Arrange
+        const string keyA = "POST:/ab:cd";
+        const string keyB = "POST:/a:bcd";
+        var store = CreateDistributedCacheStore();
+
+        // Act
+        var responseA = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"key\": \"A\"}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        
+        var responseB = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"key\": \"B\"}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        await store.MarkKeyAsProcessedAsync(MakeKey(keyA), responseA);
+        await store.MarkKeyAsProcessedAsync(MakeKey(keyB), responseB);
+
+        var resultA = await store.IsKeyProcessedAsync(MakeKey(keyA));
+        var resultB = await store.IsKeyProcessedAsync(MakeKey(keyB));
+
+        // Assert
+        resultA.processed.ShouldBeTrue();
+        resultB.processed.ShouldBeTrue();
+        resultA.response!.Body.ShouldBe("{\"key\": \"A\"}");
+        resultB.response!.Body.ShouldBe("{\"key\": \"B\"}");
+    }
+
+    [Fact]
+    public async Task DistributedCache_SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    {
+        // Arrange
+        string[] keys = ["GET:/a/b:x", "GET:/a:b/x", "GET:/ab:x"];
+        var store = CreateDistributedCacheStore();
+        var responses = new List<CachedResponse>();
+
+        // Act
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var response = new CachedResponse
+            {
+                StatusCode = 200,
+                Body = $"{{\"key\": {i}}}",
+                ContentType = "application/json",
+                CreatedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+            };
+            
+            responses.Add(response);
+            await store.MarkKeyAsProcessedAsync(MakeKey(keys[i]), response);
+        }
+
+        // Assert
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var result = await store.IsKeyProcessedAsync(MakeKey(keys[i]));
+            result.processed.ShouldBeTrue();
+            result.response!.Body.ShouldBe($"{{\"key\": {i}}}");
+        }
+    }
+
+    [Fact]
+    public async Task DistributedCache_SanitizeKey_SameInputTwice_IsDeterministic()
+    {
+        // Arrange
+        const string key = "GET:/api/orders:idem-key-123";
+        var store = CreateDistributedCacheStore();
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"id\": 123}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act
+        await store.MarkKeyAsProcessedAsync(MakeKey(key), response);
+        var result1 = await store.IsKeyProcessedAsync(MakeKey(key));
+        var result2 = await store.IsKeyProcessedAsync(MakeKey(key));
+
+        // Assert
+        result1.processed.ShouldBeTrue();
+        result2.processed.ShouldBeTrue();
+        result1.response!.Body.ShouldBe("{\"id\": 123}");
+        result2.response!.Body.ShouldBe("{\"id\": 123}");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task DistributedCache_SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
+    {
+        // Arrange
+        var store = CreateDistributedCacheStore();
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act & Assert
+        // Test the SanitizeKey method directly since that's where the validation happens
+        var ex = Should.Throw<System.Reflection.TargetInvocationException>(() => 
+        {
+            // Access the private SanitizeKey method through reflection
+            var method = typeof(IdempotencyDistributedCacheStore).GetMethod("SanitizeKey", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var field = typeof(IdempotencyDistributedCacheStore).GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var options = (IdempotencyOptions)field!.GetValue(store)!;
+            var logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger("test");
+            var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+            var directStore = new IdempotencyDistributedCacheStore(cache, Options.Create(options), logger);
+            method!.Invoke(directStore, [key]);
+        });
+        
+        // The TargetInvocationException wraps the actual ArgumentException
+        ex.InnerException.ShouldNotBeNull();
+        ex.InnerException.ShouldBeOfType<ArgumentException>();
+        ex.InnerException.Message.ShouldContain("Idempotency key cannot be null or empty");
+    }
+
+    #endregion
+}

--- a/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
+++ b/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="IdempotencyKeyEntityTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+namespace AspCore.Idempotency.NpgsqlStore.Tests.Unit;
+
+/// <summary>
+///     Unit tests for <see cref="IdempotencyKeyEntity.SanitizeKey" />.
+/// </summary>
+public sealed class IdempotencyKeyEntityTests
+{
+    #region Methods
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
+    {
+        // Act
+        var act = () => IdempotencyKeyEntity.SanitizeKey(key!);
+
+        // Assert
+        Should.Throw<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    {
+        // Arrange
+        const string keyA = "POST:/ab:cd";
+        const string keyB = "POST:/a:bcd";
+
+        // Act
+        var sanitizedA = IdempotencyKeyEntity.SanitizeKey(keyA);
+        var sanitizedB = IdempotencyKeyEntity.SanitizeKey(keyB);
+
+        // Assert
+        sanitizedA.ShouldNotBe(sanitizedB);
+    }
+
+    [Fact]
+    public void SanitizeKey_SameInputTwice_IsDeterministicBoundedAndNonEmpty()
+    {
+        // Arrange
+        const string key = "GET:/api/orders:idem-key-123";
+
+        // Act
+        var first = IdempotencyKeyEntity.SanitizeKey(key);
+        var second = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        first.ShouldBe(second);
+        first.ShouldNotBeNullOrEmpty();
+        first.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    [Fact]
+    public void SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    {
+        // Arrange
+        string[] keys =
+        [
+            "GET:/a/b:x",
+            "GET:/a:b/x",
+            "GET:/ab:x"
+        ];
+
+        // Act
+        var sanitized = keys.Select(IdempotencyKeyEntity.SanitizeKey).ToArray();
+
+        // Assert
+        sanitized.Distinct().Count().ShouldBe(sanitized.Length);
+    }
+
+    [Fact]
+    public void SanitizeKey_VeryLongCompositeKey_HashesSuccessfully()
+    {
+        // Arrange
+        var key = $"{new string('M', 20)}:{new string('E', 250)}:{new string('K', 150)}";
+
+        // Act
+        var sanitized = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        sanitized.ShouldNotBeNullOrEmpty();
+        sanitized.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    #endregion
+}

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
@@ -5,46 +5,46 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace AspCore.Idempotency.NpgsqlStore.Tests.Unit;
+namespace AspCore.Idempotency.Tests.Unit;
 
 /// <summary>
-///     Tests for idempotency store edge cases not covered
-///     by the main repository tests, specifically for NpgsqlStore's SanitizeKey implementation.
+///     Tests for <see cref="IdempotencyDistributedCacheStore" /> edge cases not covered
+///     by the main repository tests, specifically for collision detection and deterministic behavior.
 /// </summary>
-public class IdempotencyNpgsqlStoreTests
+public class IdempotencyDistributedCacheStoreTests
 {
     #region Fields
 
     private readonly IDistributedCache _cache;
-    private readonly ILogger<IdempotencyNpgsqlStoreTests> _logger;
+    private readonly ILogger<IdempotencyEndpointFilter> _logger;
 
     #endregion
 
     #region Constructors
 
-    public IdempotencyNpgsqlStoreTests()
+    public IdempotencyDistributedCacheStoreTests()
     {
         _cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
-        _logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<IdempotencyNpgsqlStoreTests>();
+        _logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<IdempotencyEndpointFilter>();
     }
 
     #endregion
 
     #region Methods
 
-    private IIdempotencyKeyStore CreateDistributedCacheStore(IdempotencyOptions? options = null) =>
-        new IdempotencyDistributedCacheStore(_cache, Options.Create(options ?? new IdempotencyOptions()), _logger);
+    private IdempotencyDistributedCacheStore CreateStore(IdempotencyOptions? options = null) =>
+        new(_cache, Options.Create(options ?? new IdempotencyOptions()), _logger);
 
     private static IdempotentKeyInfo MakeKey(string key) =>
         new() { IdempotentKey = key, Endpoint = "/api/test", Method = "POST" };
 
     [Fact]
-    public async Task DistributedCache_SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    public async Task SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
     {
         // Arrange
         const string keyA = "POST:/ab:cd";
         const string keyB = "POST:/a:bcd";
-        var store = CreateDistributedCacheStore();
+        var store = CreateStore();
 
         // Act
         var responseA = new CachedResponse
@@ -79,11 +79,11 @@ public class IdempotencyNpgsqlStoreTests
     }
 
     [Fact]
-    public async Task DistributedCache_SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    public async Task SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
     {
         // Arrange
         string[] keys = ["GET:/a/b:x", "GET:/a:b/x", "GET:/ab:x"];
-        var store = CreateDistributedCacheStore();
+        var store = CreateStore();
         var responses = new List<CachedResponse>();
 
         // Act
@@ -112,11 +112,11 @@ public class IdempotencyNpgsqlStoreTests
     }
 
     [Fact]
-    public async Task DistributedCache_SanitizeKey_SameInputTwice_IsDeterministic()
+    public async Task SanitizeKey_SameInputTwice_IsDeterministic()
     {
         // Arrange
         const string key = "GET:/api/orders:idem-key-123";
-        var store = CreateDistributedCacheStore();
+        var store = CreateStore();
         var response = new CachedResponse
         {
             StatusCode = 200,
@@ -136,43 +136,6 @@ public class IdempotencyNpgsqlStoreTests
         result2.processed.ShouldBeTrue();
         result1.response!.Body.ShouldBe("{\"id\": 123}");
         result2.response!.Body.ShouldBe("{\"id\": 123}");
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task DistributedCache_SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
-    {
-        // Arrange
-        var store = CreateDistributedCacheStore();
-        var response = new CachedResponse
-        {
-            StatusCode = 200,
-            Body = "{}",
-            ContentType = "application/json",
-            CreatedAt = DateTimeOffset.UtcNow,
-            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
-        };
-
-        // Act & Assert
-        // Test the SanitizeKey method directly since that's where the validation happens
-        var ex = Should.Throw<System.Reflection.TargetInvocationException>(() => 
-        {
-            // Access the private SanitizeKey method through reflection
-            var method = typeof(IdempotencyDistributedCacheStore).GetMethod("SanitizeKey", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var field = typeof(IdempotencyDistributedCacheStore).GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var options = (IdempotencyOptions)field!.GetValue(store)!;
-            var logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger("test");
-            var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
-            var directStore = new IdempotencyDistributedCacheStore(cache, Options.Create(options), logger);
-            method!.Invoke(directStore, [key]);
-        });
-        
-        // The TargetInvocationException wraps the actual ArgumentException
-        ex.InnerException.ShouldNotBeNull();
-        ex.InnerException.ShouldBeOfType<ArgumentException>();
-        ex.InnerException.Message.ShouldContain("Idempotency key cannot be null or empty");
     }
 
     #endregion

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyKeyRepositoryTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyKeyRepositoryTests.cs
@@ -76,11 +76,11 @@ public class IdempotencyKeyRepositoryTests
         await repository.MarkKeyAsProcessedAsync(CreateKeyInfo(idempotencyKey1), cachedResponse);
         var result = await repository.IsKeyProcessedAsync(CreateKeyInfo(idempotencyKey2));
 
-        // Assert
-        result.processed.ShouldBeTrue();
-        result.response.ShouldNotBeNull();
-        result.response!.Body.ShouldBe(cachedResponse.Body);
-        result.response.StatusCode.ShouldBe(cachedResponse.StatusCode);
+        // Assert — SanitizeKey now hashes the raw key, so keys differing only by case
+        // must be treated as distinct entries (DRK-146); marking one processed must not
+        // make the other appear processed.
+        result.processed.ShouldBeFalse();
+        result.response.ShouldBeNull();
     }
 
     [Fact]

--- a/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Data/IdempotencyKeyEntity.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Data/IdempotencyKeyEntity.cs
@@ -5,7 +5,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.RegularExpressions;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace DKNet.AspCore.Idempotency.NpgsqlStore.Data;
 
@@ -101,25 +102,18 @@ internal sealed class IdempotencyKeyEntity
     #region Methods
 
     /// <summary>
-    ///     Sanitizes an idempotency key for use as a database key.
-    ///     Removes invalid characters to prevent injection attacks.
+    ///     Sanitizes an idempotency key for use as a database key by hashing it.
+    ///     Hashing (rather than stripping characters) guarantees structurally distinct
+    ///     composite keys never collapse onto the same database key.
     /// </summary>
     /// <param name="key">The idempotency key to sanitize.</param>
-    /// <returns>A sanitized key with only alphanumeric characters and hyphens.</returns>
+    /// <returns>A deterministic, fixed-length (64-character) uppercase hex SHA-256 hash of the key.</returns>
     internal static string SanitizeKey(string key)
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
 
-        // Remove non-alphanumeric characters except hyphens
-        var sanitized = Regex.Replace(key, @"[^a-zA-Z0-9\-]", string.Empty);
-
-        if (string.IsNullOrEmpty(sanitized))
-            throw new ArgumentException("Idempotency key contains no valid characters.", nameof(key));
-
-        if (sanitized.Length > 128) sanitized = sanitized[..128];
-
-        return sanitized.ToUpperInvariant();
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key)));
     }
 
     #endregion

--- a/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
@@ -7,10 +7,14 @@ using Microsoft.Extensions.Options;
 
 namespace DKNet.AspCore.Idempotency.Store;
 
-internal sealed class IdempotencyDistributedCacheStore(
+/// <summary>
+///     Implementation of <see cref="IIdempotencyKeyStore" /> using a distributed cache.
+///     This store provides idempotency support by caching processed keys and their responses.
+/// </summary>
+public sealed class IdempotencyDistributedCacheStore(
     IDistributedCache cache,
     IOptions<IdempotencyOptions> options,
-    ILogger<IdempotencyEndpointFilter> logger) : IIdempotencyKeyStore
+    ILogger logger) : IIdempotencyKeyStore
 {
     #region Fields
 
@@ -99,8 +103,12 @@ internal sealed class IdempotencyDistributedCacheStore(
     ///     The configured cache prefix followed by a deterministic, fixed-length (64-character)
     ///     lowercase hex SHA-256 hash of the key.
     /// </returns>
-    private string SanitizeKey(string key)
+    /// <exception cref="ArgumentException">Thrown when the key is null, empty, or whitespace.</exception>
+    internal string SanitizeKey(string key)
     {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
+
         return $"{_options.CachePrefix}{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant()}";
     }
 

--- a/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
@@ -11,10 +11,10 @@ namespace DKNet.AspCore.Idempotency.Store;
 ///     Implementation of <see cref="IIdempotencyKeyStore" /> using a distributed cache.
 ///     This store provides idempotency support by caching processed keys and their responses.
 /// </summary>
-public sealed class IdempotencyDistributedCacheStore(
+internal sealed class IdempotencyDistributedCacheStore(
     IDistributedCache cache,
     IOptions<IdempotencyOptions> options,
-    ILogger logger) : IIdempotencyKeyStore
+    ILogger<IdempotencyEndpointFilter> logger) : IIdempotencyKeyStore
 {
     #region Fields
 
@@ -103,12 +103,8 @@ public sealed class IdempotencyDistributedCacheStore(
     ///     The configured cache prefix followed by a deterministic, fixed-length (64-character)
     ///     lowercase hex SHA-256 hash of the key.
     /// </returns>
-    /// <exception cref="ArgumentException">Thrown when the key is null, empty, or whitespace.</exception>
-    internal string SanitizeKey(string key)
+    private string SanitizeKey(string key)
     {
-        if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
-
         return $"{_options.CachePrefix}{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant()}";
     }
 

--- a/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
@@ -87,23 +89,19 @@ internal sealed class IdempotencyDistributedCacheStore(
     }
 
     /// <summary>
-    ///     Sanitizes an idempotency key for use as a cache key by removing or replacing invalid characters.
-    ///     This prevents cache key injection attacks by normalizing the input.
-    ///     The sanitized key is prefixed with the configured cache prefix and converted to uppercase.
+    ///     Sanitizes an idempotency key for use as a cache key by hashing it.
+    ///     Hashing (rather than replacing characters) guarantees structurally distinct
+    ///     composite keys never collapse onto the same cache key. The configured cache
+    ///     prefix is prepended unchanged.
     /// </summary>
     /// <param name="key">The idempotency key to sanitize.</param>
     /// <returns>
-    ///     A sanitized cache key with invalid characters removed and the configured prefix prepended,
-    ///     converted to uppercase for consistency.
+    ///     The configured cache prefix followed by a deterministic, fixed-length (64-character)
+    ///     lowercase hex SHA-256 hash of the key.
     /// </returns>
     private string SanitizeKey(string key)
     {
-        var k = key
-            .Replace("/", "_", StringComparison.OrdinalIgnoreCase)
-            .Replace("\n", string.Empty, StringComparison.OrdinalIgnoreCase)
-            .Replace("\r", string.Empty, StringComparison.OrdinalIgnoreCase); // Sanitize user input
-
-        return $"{_options.CachePrefix}{k}".ToLowerInvariant();
+        return $"{_options.CachePrefix}{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant()}";
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Fixes idempotency `SanitizeKey` collision defects in `DKNet.AspCore.Idempotency.NpgsqlStore` and `DKNet.AspCore.Idempotency` (`IdempotencyDistributedCacheStore`) — same defect class already fixed for `MsSqlStore` in PR #334. Both stores derived their persistent/cache lookup key via lossy sanitization (character stripping / case-folding), so structurally distinct composite keys could collapse onto the same stored key, serving one request's cached response to an unrelated request (idempotency cache poisoning).

## Changes

- `NpgsqlStore.IdempotencyKeyEntity.SanitizeKey`: regex character-stripping → SHA-256 hex hash (mirrors the merged `MsSqlStore` fix exactly).
- `IdempotencyDistributedCacheStore.SanitizeKey`: `/`→`_` replace + whole-string lowercase → SHA-256 hash of the raw key, with the configured cache prefix preserved and only the hex digest lowercased.
- Unit tests added/updated for both stores proving previously-colliding composite keys now sanitize distinct, and that derivation stays deterministic.
- `MsSqlStore` is untouched — already fixed.

## Notes

- No consumer-facing API change — both `SanitizeKey` methods keep their original visibility and signatures.
- No schema/migration change — SHA-256 hex (64 chars) fits the existing `varchar(128)` `CompositeKey` column.
- Entries stored under the old (pre-fix) key format simply won't be found after upgrade — accepted, idempotency entries are short-lived and expire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
