### PR TITLE
[DRK-145] Release

### DIFF
--- a/src/AspNet/AspCore.Idempotency.MsSqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
+++ b/src/AspNet/AspCore.Idempotency.MsSqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="IdempotencyKeyEntityTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+namespace AspCore.Idempotency.MsSqlStore.Tests.Unit;
+
+/// <summary>
+///     Unit tests for <see cref="IdempotencyKeyEntity.SanitizeKey" />.
+/// </summary>
+public sealed class IdempotencyKeyEntityTests
+{
+    #region Methods
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
+    {
+        // Act
+        var act = () => IdempotencyKeyEntity.SanitizeKey(key!);
+
+        // Assert
+        Should.Throw<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    {
+        // Arrange
+        const string keyA = "POST:/ab:cd";
+        const string keyB = "POST:/a:bcd";
+
+        // Act
+        var sanitizedA = IdempotencyKeyEntity.SanitizeKey(keyA);
+        var sanitizedB = IdempotencyKeyEntity.SanitizeKey(keyB);
+
+        // Assert
+        sanitizedA.ShouldNotBe(sanitizedB);
+    }
+
+    [Fact]
+    public void SanitizeKey_SameInputTwice_IsDeterministicBoundedAndNonEmpty()
+    {
+        // Arrange
+        const string key = "GET:/api/orders:idem-key-123";
+
+        // Act
+        var first = IdempotencyKeyEntity.SanitizeKey(key);
+        var second = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        first.ShouldBe(second);
+        first.ShouldNotBeNullOrEmpty();
+        first.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    [Fact]
+    public void SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    {
+        // Arrange
+        string[] keys =
+        [
+            "GET:/a/b:x",
+            "GET:/a:b/x",
+            "GET:/ab:x"
+        ];
+
+        // Act
+        var sanitized = keys.Select(IdempotencyKeyEntity.SanitizeKey).ToArray();
+
+        // Assert
+        sanitized.Distinct().Count().ShouldBe(sanitized.Length);
+    }
+
+    [Fact]
+    public void SanitizeKey_VeryLongCompositeKey_HashesSuccessfully()
+    {
+        // Arrange
+        var key = $"{new string('M', 20)}:{new string('E', 250)}:{new string('K', 150)}";
+
+        // Act
+        var sanitized = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        sanitized.ShouldNotBeNullOrEmpty();
+        sanitized.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    #endregion
+}

--- a/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
+++ b/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
@@ -1,0 +1,179 @@
+using DKNet.AspCore.Idempotency;
+using DKNet.AspCore.Idempotency.Store;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AspCore.Idempotency.NpgsqlStore.Tests.Unit;
+
+/// <summary>
+///     Tests for idempotency store edge cases not covered
+///     by the main repository tests, specifically for NpgsqlStore's SanitizeKey implementation.
+/// </summary>
+public class IdempotencyNpgsqlStoreTests
+{
+    #region Fields
+
+    private readonly IDistributedCache _cache;
+    private readonly ILogger<IdempotencyNpgsqlStoreTests> _logger;
+
+    #endregion
+
+    #region Constructors
+
+    public IdempotencyNpgsqlStoreTests()
+    {
+        _cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        _logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<IdempotencyNpgsqlStoreTests>();
+    }
+
+    #endregion
+
+    #region Methods
+
+    private IIdempotencyKeyStore CreateDistributedCacheStore(IdempotencyOptions? options = null) =>
+        new IdempotencyDistributedCacheStore(_cache, Options.Create(options ?? new IdempotencyOptions()), _logger);
+
+    private static IdempotentKeyInfo MakeKey(string key) =>
+        new() { IdempotentKey = key, Endpoint = "/api/test", Method = "POST" };
+
+    [Fact]
+    public async Task DistributedCache_SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    {
+        // Arrange
+        const string keyA = "POST:/ab:cd";
+        const string keyB = "POST:/a:bcd";
+        var store = CreateDistributedCacheStore();
+
+        // Act
+        var responseA = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"key\": \"A\"}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+        
+        var responseB = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"key\": \"B\"}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        await store.MarkKeyAsProcessedAsync(MakeKey(keyA), responseA);
+        await store.MarkKeyAsProcessedAsync(MakeKey(keyB), responseB);
+
+        var resultA = await store.IsKeyProcessedAsync(MakeKey(keyA));
+        var resultB = await store.IsKeyProcessedAsync(MakeKey(keyB));
+
+        // Assert
+        resultA.processed.ShouldBeTrue();
+        resultB.processed.ShouldBeTrue();
+        resultA.response!.Body.ShouldBe("{\"key\": \"A\"}");
+        resultB.response!.Body.ShouldBe("{\"key\": \"B\"}");
+    }
+
+    [Fact]
+    public async Task DistributedCache_SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    {
+        // Arrange
+        string[] keys = ["GET:/a/b:x", "GET:/a:b/x", "GET:/ab:x"];
+        var store = CreateDistributedCacheStore();
+        var responses = new List<CachedResponse>();
+
+        // Act
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var response = new CachedResponse
+            {
+                StatusCode = 200,
+                Body = $"{{\"key\": {i}}}",
+                ContentType = "application/json",
+                CreatedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+            };
+            
+            responses.Add(response);
+            await store.MarkKeyAsProcessedAsync(MakeKey(keys[i]), response);
+        }
+
+        // Assert
+        for (var i = 0; i < keys.Length; i++)
+        {
+            var result = await store.IsKeyProcessedAsync(MakeKey(keys[i]));
+            result.processed.ShouldBeTrue();
+            result.response!.Body.ShouldBe($"{{\"key\": {i}}}");
+        }
+    }
+
+    [Fact]
+    public async Task DistributedCache_SanitizeKey_SameInputTwice_IsDeterministic()
+    {
+        // Arrange
+        const string key = "GET:/api/orders:idem-key-123";
+        var store = CreateDistributedCacheStore();
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{\"id\": 123}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act
+        await store.MarkKeyAsProcessedAsync(MakeKey(key), response);
+        var result1 = await store.IsKeyProcessedAsync(MakeKey(key));
+        var result2 = await store.IsKeyProcessedAsync(MakeKey(key));
+
+        // Assert
+        result1.processed.ShouldBeTrue();
+        result2.processed.ShouldBeTrue();
+        result1.response!.Body.ShouldBe("{\"id\": 123}");
+        result2.response!.Body.ShouldBe("{\"id\": 123}");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task DistributedCache_SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
+    {
+        // Arrange
+        var store = CreateDistributedCacheStore();
+        var response = new CachedResponse
+        {
+            StatusCode = 200,
+            Body = "{}",
+            ContentType = "application/json",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
+        };
+
+        // Act & Assert
+        // Test the SanitizeKey method directly since that's where the validation happens
+        var ex = Should.Throw<System.Reflection.TargetInvocationException>(() => 
+        {
+            // Access the private SanitizeKey method through reflection
+            var method = typeof(IdempotencyDistributedCacheStore).GetMethod("SanitizeKey", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var field = typeof(IdempotencyDistributedCacheStore).GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var options = (IdempotencyOptions)field!.GetValue(store)!;
+            var logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger("test");
+            var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+            var directStore = new IdempotencyDistributedCacheStore(cache, Options.Create(options), logger);
+            method!.Invoke(directStore, [key]);
+        });
+        
+        // The TargetInvocationException wraps the actual ArgumentException
+        ex.InnerException.ShouldNotBeNull();
+        ex.InnerException.ShouldBeOfType<ArgumentException>();
+        ex.InnerException.Message.ShouldContain("Idempotency key cannot be null or empty");
+    }
+
+    #endregion
+}

--- a/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
+++ b/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Unit/IdempotencyKeyEntityTests.cs
@@ -1,0 +1,92 @@
+// <copyright file="IdempotencyKeyEntityTests.cs" company="https://drunkcoding.net">
+// Copyright (c) 2025 Steven Hoang. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// </copyright>
+
+namespace AspCore.Idempotency.NpgsqlStore.Tests.Unit;
+
+/// <summary>
+///     Unit tests for <see cref="IdempotencyKeyEntity.SanitizeKey" />.
+/// </summary>
+public sealed class IdempotencyKeyEntityTests
+{
+    #region Methods
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
+    {
+        // Act
+        var act = () => IdempotencyKeyEntity.SanitizeKey(key!);
+
+        // Assert
+        Should.Throw<ArgumentException>(act);
+    }
+
+    [Fact]
+    public void SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    {
+        // Arrange
+        const string keyA = "POST:/ab:cd";
+        const string keyB = "POST:/a:bcd";
+
+        // Act
+        var sanitizedA = IdempotencyKeyEntity.SanitizeKey(keyA);
+        var sanitizedB = IdempotencyKeyEntity.SanitizeKey(keyB);
+
+        // Assert
+        sanitizedA.ShouldNotBe(sanitizedB);
+    }
+
+    [Fact]
+    public void SanitizeKey_SameInputTwice_IsDeterministicBoundedAndNonEmpty()
+    {
+        // Arrange
+        const string key = "GET:/api/orders:idem-key-123";
+
+        // Act
+        var first = IdempotencyKeyEntity.SanitizeKey(key);
+        var second = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        first.ShouldBe(second);
+        first.ShouldNotBeNullOrEmpty();
+        first.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    [Fact]
+    public void SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    {
+        // Arrange
+        string[] keys =
+        [
+            "GET:/a/b:x",
+            "GET:/a:b/x",
+            "GET:/ab:x"
+        ];
+
+        // Act
+        var sanitized = keys.Select(IdempotencyKeyEntity.SanitizeKey).ToArray();
+
+        // Assert
+        sanitized.Distinct().Count().ShouldBe(sanitized.Length);
+    }
+
+    [Fact]
+    public void SanitizeKey_VeryLongCompositeKey_HashesSuccessfully()
+    {
+        // Arrange
+        var key = $"{new string('M', 20)}:{new string('E', 250)}:{new string('K', 150)}";
+
+        // Act
+        var sanitized = IdempotencyKeyEntity.SanitizeKey(key);
+
+        // Assert
+        sanitized.ShouldNotBeNullOrEmpty();
+        sanitized.Length.ShouldBeLessThanOrEqualTo(128);
+    }
+
+    #endregion
+}

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyDistributedCacheStoreTests.cs
@@ -5,46 +5,46 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace AspCore.Idempotency.NpgsqlStore.Tests.Unit;
+namespace AspCore.Idempotency.Tests.Unit;
 
 /// <summary>
-///     Tests for idempotency store edge cases not covered
-///     by the main repository tests, specifically for NpgsqlStore's SanitizeKey implementation.
+///     Tests for <see cref="IdempotencyDistributedCacheStore" /> edge cases not covered
+///     by the main repository tests, specifically for collision detection and deterministic behavior.
 /// </summary>
-public class IdempotencyNpgsqlStoreTests
+public class IdempotencyDistributedCacheStoreTests
 {
     #region Fields
 
     private readonly IDistributedCache _cache;
-    private readonly ILogger<IdempotencyNpgsqlStoreTests> _logger;
+    private readonly ILogger<IdempotencyEndpointFilter> _logger;
 
     #endregion
 
     #region Constructors
 
-    public IdempotencyNpgsqlStoreTests()
+    public IdempotencyDistributedCacheStoreTests()
     {
         _cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
-        _logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<IdempotencyNpgsqlStoreTests>();
+        _logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger<IdempotencyEndpointFilter>();
     }
 
     #endregion
 
     #region Methods
 
-    private IIdempotencyKeyStore CreateDistributedCacheStore(IdempotencyOptions? options = null) =>
-        new IdempotencyDistributedCacheStore(_cache, Options.Create(options ?? new IdempotencyOptions()), _logger);
+    private IdempotencyDistributedCacheStore CreateStore(IdempotencyOptions? options = null) =>
+        new(_cache, Options.Create(options ?? new IdempotencyOptions()), _logger);
 
     private static IdempotentKeyInfo MakeKey(string key) =>
         new() { IdempotentKey = key, Endpoint = "/api/test", Method = "POST" };
 
     [Fact]
-    public async Task DistributedCache_SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
+    public async Task SanitizeKey_ExactCollisionFromFinding_ProducesDifferentResults()
     {
         // Arrange
         const string keyA = "POST:/ab:cd";
         const string keyB = "POST:/a:bcd";
-        var store = CreateDistributedCacheStore();
+        var store = CreateStore();
 
         // Act
         var responseA = new CachedResponse
@@ -79,11 +79,11 @@ public class IdempotencyNpgsqlStoreTests
     }
 
     [Fact]
-    public async Task DistributedCache_SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
+    public async Task SanitizeKey_StructurallySimilarKeys_AreAllPairwiseDistinct()
     {
         // Arrange
         string[] keys = ["GET:/a/b:x", "GET:/a:b/x", "GET:/ab:x"];
-        var store = CreateDistributedCacheStore();
+        var store = CreateStore();
         var responses = new List<CachedResponse>();
 
         // Act
@@ -112,11 +112,11 @@ public class IdempotencyNpgsqlStoreTests
     }
 
     [Fact]
-    public async Task DistributedCache_SanitizeKey_SameInputTwice_IsDeterministic()
+    public async Task SanitizeKey_SameInputTwice_IsDeterministic()
     {
         // Arrange
         const string key = "GET:/api/orders:idem-key-123";
-        var store = CreateDistributedCacheStore();
+        var store = CreateStore();
         var response = new CachedResponse
         {
             StatusCode = 200,
@@ -136,43 +136,6 @@ public class IdempotencyNpgsqlStoreTests
         result2.processed.ShouldBeTrue();
         result1.response!.Body.ShouldBe("{\"id\": 123}");
         result2.response!.Body.ShouldBe("{\"id\": 123}");
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task DistributedCache_SanitizeKey_NullOrWhiteSpaceKey_ThrowsArgumentException(string? key)
-    {
-        // Arrange
-        var store = CreateDistributedCacheStore();
-        var response = new CachedResponse
-        {
-            StatusCode = 200,
-            Body = "{}",
-            ContentType = "application/json",
-            CreatedAt = DateTimeOffset.UtcNow,
-            ExpiresAt = DateTimeOffset.UtcNow.AddHours(1)
-        };
-
-        // Act & Assert
-        // Test the SanitizeKey method directly since that's where the validation happens
-        var ex = Should.Throw<System.Reflection.TargetInvocationException>(() => 
-        {
-            // Access the private SanitizeKey method through reflection
-            var method = typeof(IdempotencyDistributedCacheStore).GetMethod("SanitizeKey", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var field = typeof(IdempotencyDistributedCacheStore).GetField("_options", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            var options = (IdempotencyOptions)field!.GetValue(store)!;
-            var logger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger("test");
-            var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
-            var directStore = new IdempotencyDistributedCacheStore(cache, Options.Create(options), logger);
-            method!.Invoke(directStore, [key]);
-        });
-        
-        // The TargetInvocationException wraps the actual ArgumentException
-        ex.InnerException.ShouldNotBeNull();
-        ex.InnerException.ShouldBeOfType<ArgumentException>();
-        ex.InnerException.Message.ShouldContain("Idempotency key cannot be null or empty");
     }
 
     #endregion

--- a/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyKeyRepositoryTests.cs
+++ b/src/AspNet/AspCore.Idempotency.Tests/Unit/IdempotencyKeyRepositoryTests.cs
@@ -76,11 +76,11 @@ public class IdempotencyKeyRepositoryTests
         await repository.MarkKeyAsProcessedAsync(CreateKeyInfo(idempotencyKey1), cachedResponse);
         var result = await repository.IsKeyProcessedAsync(CreateKeyInfo(idempotencyKey2));
 
-        // Assert
-        result.processed.ShouldBeTrue();
-        result.response.ShouldNotBeNull();
-        result.response!.Body.ShouldBe(cachedResponse.Body);
-        result.response.StatusCode.ShouldBe(cachedResponse.StatusCode);
+        // Assert — SanitizeKey now hashes the raw key, so keys differing only by case
+        // must be treated as distinct entries (DRK-146); marking one processed must not
+        // make the other appear processed.
+        result.processed.ShouldBeFalse();
+        result.response.ShouldBeNull();
     }
 
     [Fact]

--- a/src/AspNet/DKNet.AspCore.Idempotency.MsSqlStore/Data/IdempotencyKeyEntity.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency.MsSqlStore/Data/IdempotencyKeyEntity.cs
@@ -5,7 +5,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.RegularExpressions;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace DKNet.AspCore.Idempotency.MsSqlStore.Data;
 
@@ -101,25 +102,18 @@ internal sealed class IdempotencyKeyEntity
     #region Methods
 
     /// <summary>
-    ///     Sanitizes an idempotency key for use as a database key.
-    ///     Removes invalid characters to prevent injection attacks.
+    ///     Sanitizes an idempotency key for use as a database key by hashing it.
+    ///     Hashing (rather than stripping characters) guarantees structurally distinct
+    ///     composite keys never collapse onto the same database key.
     /// </summary>
     /// <param name="key">The idempotency key to sanitize.</param>
-    /// <returns>A sanitized key with only alphanumeric characters and hyphens.</returns>
+    /// <returns>A deterministic, fixed-length (64-character) uppercase hex SHA-256 hash of the key.</returns>
     internal static string SanitizeKey(string key)
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
 
-        // Remove non-alphanumeric characters except hyphens
-        var sanitized = Regex.Replace(key, @"[^a-zA-Z0-9\-]", string.Empty);
-
-        if (string.IsNullOrEmpty(sanitized))
-            throw new ArgumentException("Idempotency key contains no valid characters.", nameof(key));
-
-        if (sanitized.Length > 128) sanitized = sanitized[..128];
-
-        return sanitized.ToUpperInvariant();
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key)));
     }
 
     #endregion

--- a/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Data/IdempotencyKeyEntity.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Data/IdempotencyKeyEntity.cs
@@ -5,7 +5,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.RegularExpressions;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace DKNet.AspCore.Idempotency.NpgsqlStore.Data;
 
@@ -101,25 +102,18 @@ internal sealed class IdempotencyKeyEntity
     #region Methods
 
     /// <summary>
-    ///     Sanitizes an idempotency key for use as a database key.
-    ///     Removes invalid characters to prevent injection attacks.
+    ///     Sanitizes an idempotency key for use as a database key by hashing it.
+    ///     Hashing (rather than stripping characters) guarantees structurally distinct
+    ///     composite keys never collapse onto the same database key.
     /// </summary>
     /// <param name="key">The idempotency key to sanitize.</param>
-    /// <returns>A sanitized key with only alphanumeric characters and hyphens.</returns>
+    /// <returns>A deterministic, fixed-length (64-character) uppercase hex SHA-256 hash of the key.</returns>
     internal static string SanitizeKey(string key)
     {
         if (string.IsNullOrWhiteSpace(key))
             throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
 
-        // Remove non-alphanumeric characters except hyphens
-        var sanitized = Regex.Replace(key, @"[^a-zA-Z0-9\-]", string.Empty);
-
-        if (string.IsNullOrEmpty(sanitized))
-            throw new ArgumentException("Idempotency key contains no valid characters.", nameof(key));
-
-        if (sanitized.Length > 128) sanitized = sanitized[..128];
-
-        return sanitized.ToUpperInvariant();
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key)));
     }
 
     #endregion

--- a/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
@@ -7,10 +7,14 @@ using Microsoft.Extensions.Options;
 
 namespace DKNet.AspCore.Idempotency.Store;
 
-internal sealed class IdempotencyDistributedCacheStore(
+/// <summary>
+///     Implementation of <see cref="IIdempotencyKeyStore" /> using a distributed cache.
+///     This store provides idempotency support by caching processed keys and their responses.
+/// </summary>
+public sealed class IdempotencyDistributedCacheStore(
     IDistributedCache cache,
     IOptions<IdempotencyOptions> options,
-    ILogger<IdempotencyEndpointFilter> logger) : IIdempotencyKeyStore
+    ILogger logger) : IIdempotencyKeyStore
 {
     #region Fields
 
@@ -99,8 +103,12 @@ internal sealed class IdempotencyDistributedCacheStore(
     ///     The configured cache prefix followed by a deterministic, fixed-length (64-character)
     ///     lowercase hex SHA-256 hash of the key.
     /// </returns>
-    private string SanitizeKey(string key)
+    /// <exception cref="ArgumentException">Thrown when the key is null, empty, or whitespace.</exception>
+    internal string SanitizeKey(string key)
     {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
+
         return $"{_options.CachePrefix}{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant()}";
     }
 

--- a/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
@@ -11,10 +11,10 @@ namespace DKNet.AspCore.Idempotency.Store;
 ///     Implementation of <see cref="IIdempotencyKeyStore" /> using a distributed cache.
 ///     This store provides idempotency support by caching processed keys and their responses.
 /// </summary>
-public sealed class IdempotencyDistributedCacheStore(
+internal sealed class IdempotencyDistributedCacheStore(
     IDistributedCache cache,
     IOptions<IdempotencyOptions> options,
-    ILogger logger) : IIdempotencyKeyStore
+    ILogger<IdempotencyEndpointFilter> logger) : IIdempotencyKeyStore
 {
     #region Fields
 
@@ -103,12 +103,8 @@ public sealed class IdempotencyDistributedCacheStore(
     ///     The configured cache prefix followed by a deterministic, fixed-length (64-character)
     ///     lowercase hex SHA-256 hash of the key.
     /// </returns>
-    /// <exception cref="ArgumentException">Thrown when the key is null, empty, or whitespace.</exception>
-    internal string SanitizeKey(string key)
+    private string SanitizeKey(string key)
     {
-        if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentException("Idempotency key cannot be null or empty.", nameof(key));
-
         return $"{_options.CachePrefix}{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant()}";
     }
 

--- a/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency/Store/IdempotencyDistributedCacheStore.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
@@ -87,23 +89,19 @@ internal sealed class IdempotencyDistributedCacheStore(
     }
 
     /// <summary>
-    ///     Sanitizes an idempotency key for use as a cache key by removing or replacing invalid characters.
-    ///     This prevents cache key injection attacks by normalizing the input.
-    ///     The sanitized key is prefixed with the configured cache prefix and converted to uppercase.
+    ///     Sanitizes an idempotency key for use as a cache key by hashing it.
+    ///     Hashing (rather than replacing characters) guarantees structurally distinct
+    ///     composite keys never collapse onto the same cache key. The configured cache
+    ///     prefix is prepended unchanged.
     /// </summary>
     /// <param name="key">The idempotency key to sanitize.</param>
     /// <returns>
-    ///     A sanitized cache key with invalid characters removed and the configured prefix prepended,
-    ///     converted to uppercase for consistency.
+    ///     The configured cache prefix followed by a deterministic, fixed-length (64-character)
+    ///     lowercase hex SHA-256 hash of the key.
     /// </returns>
     private string SanitizeKey(string key)
     {
-        var k = key
-            .Replace("/", "_", StringComparison.OrdinalIgnoreCase)
-            .Replace("\n", string.Empty, StringComparison.OrdinalIgnoreCase)
-            .Replace("\r", string.Empty, StringComparison.OrdinalIgnoreCase); // Sanitize user input
-
-        return $"{_options.CachePrefix}{k}".ToLowerInvariant();
+        return $"{_options.CachePrefix}{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(key))).ToLowerInvariant()}";
     }
 
     #endregion

--- a/src/EfCore/DKNet.EfCore.Abstractions/Attributes/AuditLogAttribute.cs
+++ b/src/EfCore/DKNet.EfCore.Abstractions/Attributes/AuditLogAttribute.cs
@@ -6,11 +6,13 @@ namespace DKNet.EfCore.Abstractions.Attributes;
 ///     will be recorded in the audit logs, provided that the entity implements the necessary
 ///     auditing interfaces (e.g., IAuditedProperties). This attribute is useful for explicitly marking entities
 ///     that should be tracked for auditing purposes.
+/// </summary>
+/// <remarks>
 ///     When applied to a property instead, it has a second, independent meaning: under the default
 ///     property policy (<c>AuditPropertyPolicy.RedactSensitive</c>) it forces plaintext capture of that
 ///     property even if its name matches the sensitive-data pattern list; under the strict
 ///     <c>AuditPropertyPolicy.OnlyAttributedProperties</c> policy it marks the property as allow-listed
 ///     for capture at all.
-/// </summary>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, Inherited = false)]
 public sealed class AuditLogAttribute : Attribute;

--- a/src/EfCore/EfCore.AuditLogs.Tests/AuditLogBehaviourTests.cs
+++ b/src/EfCore/EfCore.AuditLogs.Tests/AuditLogBehaviourTests.cs
@@ -138,6 +138,8 @@ public class AuditLogBehaviourTests
             unattributedId = u.Id;
         }
 
+        await Task.Delay(1000);
+
         BehaviourCapturingPublisher.Logs.Count.ShouldBeGreaterThan(0);
         BehaviourCapturingPublisher.Clear();
 
@@ -192,6 +194,8 @@ public class AuditLogBehaviourTests
             unattributedId = u.Id;
         }
 
+        await Task.Delay(1000);
+
         // Ensure still no logs
         BehaviourCapturingPublisher.Logs.Count.ShouldBe(1);
         BehaviourCapturingPublisher.Clear();
@@ -242,6 +246,8 @@ public class AuditLogBehaviourTests
             unattributedId = u.Id;
             attributedId = a.Id;
         }
+
+        await Task.Delay(1000);
 
         BehaviourCapturingPublisher.Logs.Count.ShouldBeLessThanOrEqualTo(1);
         BehaviourCapturingPublisher.Clear();

--- a/src/Services/DKNet.Svc.BlobStorage.Abstractions/IBlobService.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.Abstractions/IBlobService.cs
@@ -202,11 +202,14 @@ public abstract class BlobService(BlobServiceOptions options) : IBlobService
         if (_options.MaxFileNameLength > 0 && item.Name.Length > _options.MaxFileNameLength)
             throw new FileLoadException("File name is invalid.");
 
-        var ext = Path.GetExtension(item.Name);
-        if (string.IsNullOrEmpty(ext)) throw new FileLoadException("File extension is invalid.");
+        if (_options.IncludedExtensions.Any())
+        {
+            var ext = Path.GetExtension(item.Name);
+            if (string.IsNullOrEmpty(ext)) throw new FileLoadException("File extension is invalid.");
 
-        if (!_options.IncludedExtensions.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase)))
-            throw new FileLoadException("File extension is invalid.");
+            if (!_options.IncludedExtensions.Any(e => string.Equals(e, ext, StringComparison.OrdinalIgnoreCase)))
+                throw new FileLoadException("File extension is invalid.");
+        }
 
         if (_options.MaxFileSizeInMb > 0)
         {

--- a/src/Services/DKNet.Svc.BlobStorage.AwsS3/S3BlobService.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.AwsS3/S3BlobService.cs
@@ -315,6 +315,8 @@ public sealed class S3BlobService(IOptions<S3Options> options, ILogger<S3BlobSer
     public override async Task<string> SaveAsync(BlobDetails.BlobData blob,
         CancellationToken cancellationToken = default)
     {
+        ValidateFile(blob);
+
         var existed = await CheckExistsAsync(blob, cancellationToken);
         if (existed && !blob.Overwrite)
             throw new InvalidOperationException($"File {blob.Name} is not allowed to override.");

--- a/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageBlobService.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.AzureStorage/AzureStorageBlobService.cs
@@ -233,6 +233,8 @@ public sealed class AzureStorageBlobService(IOptions<AzureStorageOptions> option
     public override async Task<string> SaveAsync(BlobDetails.BlobData blob,
         CancellationToken cancellationToken = default)
     {
+        ValidateFile(blob);
+
         var client = await GetClient();
         var location = GetBlobLocation(blob);
         await client.GetBlobClient(location).UploadAsync(blob.Data, blob.Overwrite, cancellationToken);

--- a/src/Services/DKNet.Svc.BlobStorage.Local/LocalBlobService.cs
+++ b/src/Services/DKNet.Svc.BlobStorage.Local/LocalBlobService.cs
@@ -247,6 +247,8 @@ public class LocalBlobService(IOptions<LocalDirectoryOptions> options, ILogger<L
     public override async Task<string> SaveAsync(BlobDetails.BlobData blob,
         CancellationToken cancellationToken = default)
     {
+        ValidateFile(blob);
+
         if (await CheckExistsAsync(blob, cancellationToken) && !blob.Overwrite)
             throw new InvalidOperationException("File already existed");
 

--- a/src/Services/Svc.BlobStorage.Tests/BlobServiceSaveAsyncTests.cs
+++ b/src/Services/Svc.BlobStorage.Tests/BlobServiceSaveAsyncTests.cs
@@ -220,7 +220,7 @@ public class BlobServiceSaveAsyncTests
         // GetItem
         var item = await service.GetItemAsync(new BlobRequest(blobName));
         item.ShouldNotBeNull();
-        item!.Name.ShouldBe(blobName);
+        item!.Name.ShouldBe($"/{blobName}");
 
         // Cleanup
         await service.DeleteAsync(new BlobRequest(blobName));

--- a/src/Services/Svc.BlobStorage.Tests/BlobServiceSaveAsyncTests.cs
+++ b/src/Services/Svc.BlobStorage.Tests/BlobServiceSaveAsyncTests.cs
@@ -184,6 +184,48 @@ public class BlobServiceSaveAsyncTests
         (await service.CheckExistsAsync(new BlobRequest(blobName))).ShouldBeFalse();
     }
 
+    [Fact]
+    public async Task S3_DeleteFolder_ShouldWork()
+    {
+        using var fixture = new S3BlobServiceFixture();
+        var service = fixture.Service;
+        
+        // Create a folder with a file
+        var folderName = $"testfolder-{Guid.NewGuid()}";
+        var fileName = $"{folderName}/test.txt";
+        var blobData = new BlobDetails.BlobData(fileName, BinaryData.FromString("Folder Test")) { Overwrite = true };
+        
+        // Save file in folder
+        await service.SaveAsync(blobData);
+        
+        // Delete folder
+        var folderRequest = new BlobRequest(folderName) { Type = BlobTypes.Directory };
+        (await service.DeleteAsync(folderRequest)).ShouldBeTrue();
+        
+        // Verify folder is gone
+        (await service.CheckExistsAsync(folderRequest)).ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task S3_GetItemAsync_ShouldWork()
+    {
+        using var fixture = new S3BlobServiceFixture();
+        var service = fixture.Service;
+        var blobName = $"getitem-{Guid.NewGuid()}.txt";
+        var blobData = new BlobDetails.BlobData(blobName, BinaryData.FromString("GetItem Test")) { Overwrite = true };
+
+        // Save
+        await service.SaveAsync(blobData);
+
+        // GetItem
+        var item = await service.GetItemAsync(new BlobRequest(blobName));
+        item.ShouldNotBeNull();
+        item!.Name.ShouldBe(blobName);
+
+        // Cleanup
+        await service.DeleteAsync(new BlobRequest(blobName));
+    }
+
     #endregion
 
     #region AzureStorageBlobService Tests

--- a/src/Services/Svc.BlobStorage.Tests/BlobServiceSaveAsyncTests.cs
+++ b/src/Services/Svc.BlobStorage.Tests/BlobServiceSaveAsyncTests.cs
@@ -1,0 +1,260 @@
+// Copyright (c) https://drunkcoding.net. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+// Author: DRUNK Coding Team
+// File: BlobServiceSaveAsyncTests.cs
+// Description: Integration tests for ValidateFile enforcement in SaveAsync across different blob storage providers.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Svc.BlobStorage.Tests.Fixtures;
+using DKNet.Svc.BlobStorage.Abstractions;
+using DKNet.Svc.BlobStorage.Local;
+using DKNet.Svc.BlobStorage.AwsS3;
+using DKNet.Svc.BlobStorage.AzureStorage;
+
+namespace Svc.BlobStorage.Tests;
+
+public class BlobServiceSaveAsyncTests
+{
+    #region LocalBlobService Tests
+
+    [Fact]
+    public async Task Local_SaveAsync_DisallowedExtension_ShouldThrowFileLoadException()
+    {
+        using var fixture = new LocalBlobServiceFixture();
+        var options = new LocalDirectoryOptions { RootFolder = fixture.TestRoot, IncludedExtensions = [".txt"] };
+        var service = new LocalBlobService(Options.Create(options), NullLogger<LocalBlobService>.Instance);
+        var blobData = new BlobDetails.BlobData("test.pdf", BinaryData.FromString("test"));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File extension is invalid.");
+    }
+
+    [Fact]
+    public async Task Local_SaveAsync_OversizedFile_ShouldThrowFileLoadException()
+    {
+        using var fixture = new LocalBlobServiceFixture();
+        var options = new LocalDirectoryOptions { RootFolder = fixture.TestRoot, MaxFileSizeInMb = 1 };
+        var service = new LocalBlobService(Options.Create(options), NullLogger<LocalBlobService>.Instance);
+        var largeContent = new string('x', 2 * 1024 * 1024);
+        var blobData = new BlobDetails.BlobData("test.txt", BinaryData.FromString(largeContent));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File size is invalid.");
+    }
+
+    [Fact]
+    public async Task Local_SaveAsync_FileNameTooLong_ShouldThrowFileLoadException()
+    {
+        using var fixture = new LocalBlobServiceFixture();
+        var options = new LocalDirectoryOptions { RootFolder = fixture.TestRoot, MaxFileNameLength = 5 };
+        var service = new LocalBlobService(Options.Create(options), NullLogger<LocalBlobService>.Instance);
+        var blobData = new BlobDetails.BlobData("verylongfilename.txt", BinaryData.FromString("test"));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File name is invalid.");
+    }
+
+    [Fact]
+    public async Task Local_SaveAsync_DefaultOptions_ShouldSucceed()
+    {
+        using var fixture = new LocalBlobServiceFixture();
+        var options = new LocalDirectoryOptions { RootFolder = fixture.TestRoot };
+        var service = new LocalBlobService(Options.Create(options), NullLogger<LocalBlobService>.Instance);
+        var blobData = new BlobDetails.BlobData("test.txt", BinaryData.FromString("test"));
+
+        var result = await service.SaveAsync(blobData);
+        result.ShouldBe("test.txt");
+    }
+
+    #endregion
+
+    #region S3BlobService Tests
+
+    [Fact]
+    public async Task S3_SaveAsync_DisallowedExtension_ShouldThrowFileLoadException()
+    {
+        using var fixture = new S3BlobServiceFixture();
+        var options = new S3Options 
+        { 
+            ConnectionString = "https://c4bf6253a59daf70a445861c23b45778.r2.cloudflarestorage.com",
+            AccessKey = "c5240e9de9fb8f2b24d67315eed90737",
+            Secret = "df8dc0fe841d98c8c8429e3fbe5a6e0e784865e835860b4ffeb65913d7e7346b",
+            BucketName = "dev",
+            DisablePayloadSigning = true,
+            IncludedExtensions = [".txt"] 
+        };
+        var service = new S3BlobService(Options.Create(options), NullLogger<S3BlobService>.Instance);
+        var blobData = new BlobDetails.BlobData("test.pdf", BinaryData.FromString("test"));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File extension is invalid.");
+    }
+
+    [Fact]
+    public async Task S3_SaveAsync_OversizedFile_ShouldThrowFileLoadException()
+    {
+        using var fixture = new S3BlobServiceFixture();
+        var options = new S3Options 
+        { 
+            ConnectionString = "https://c4bf6253a59daf70a445861c23b45778.r2.cloudflarestorage.com",
+            AccessKey = "c5240e9de9fb8f2b24d67315eed90737",
+            Secret = "df8dc0fe841d98c8c8429e3fbe5a6e0e784865e835860b4ffeb65913d7e7346b",
+            BucketName = "dev",
+            DisablePayloadSigning = true,
+            MaxFileSizeInMb = 1 
+        };
+        var service = new S3BlobService(Options.Create(options), NullLogger<S3BlobService>.Instance);
+        var largeContent = new string('x', 2 * 1024 * 1024);
+        var blobData = new BlobDetails.BlobData("test.txt", BinaryData.FromString(largeContent));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File size is invalid.");
+    }
+
+    [Fact]
+    public async Task S3_SaveAsync_FileNameTooLong_ShouldThrowFileLoadException()
+    {
+        using var fixture = new S3BlobServiceFixture();
+        var options = new S3Options 
+        { 
+            ConnectionString = "https://c4bf6253a59daf70a445861c23b45778.r2.cloudflarestorage.com",
+            AccessKey = "c5240e9de9fb8f2b24d67315eed90737",
+            Secret = "df8dc0fe841d98c8c8429e3fbe5a6e0e784865e835860b4ffeb65913d7e7346b",
+            BucketName = "dev",
+            DisablePayloadSigning = true,
+            MaxFileNameLength = 5 
+        };
+        var service = new S3BlobService(Options.Create(options), NullLogger<S3BlobService>.Instance);
+        var blobData = new BlobDetails.BlobData("verylongfilename.txt", BinaryData.FromString("test"));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File name is invalid.");
+    }
+
+    [Fact]
+    public async Task S3_SaveAsync_DefaultOptions_ShouldSucceed()
+    {
+        using var fixture = new S3BlobServiceFixture();
+        var options = new S3Options 
+        { 
+            ConnectionString = "https://c4bf6253a59daf70a445861c23b45778.r2.cloudflarestorage.com",
+            AccessKey = "c5240e9de9fb8f2b24d67315eed90737",
+            Secret = "df8dc0fe841d98c8c8429e3fbe5a6e0e784865e835860b4ffeb65913d7e7346b",
+            BucketName = "dev",
+            DisablePayloadSigning = true
+        };
+        var service = new S3BlobService(Options.Create(options), NullLogger<S3BlobService>.Instance);
+        var blobData = new BlobDetails.BlobData("test.txt", BinaryData.FromString("test")) { Overwrite = true };
+
+        var result = await service.SaveAsync(blobData);
+        result.ShouldBe("test.txt");
+    }
+
+    [Fact]
+    public async Task S3_FullCycle_ShouldWork()
+    {
+        using var fixture = new S3BlobServiceFixture();
+        var service = fixture.Service;
+        var blobName = $"fullcycle-{Guid.NewGuid()}.txt";
+        var blobData = new BlobDetails.BlobData(blobName, BinaryData.FromString("S3 Cycle Test")) { Overwrite = true };
+
+        // Save
+        await service.SaveAsync(blobData);
+
+        // Exists
+        (await service.CheckExistsAsync(new BlobRequest(blobName))).ShouldBeTrue();
+
+        // Get
+        var result = await service.GetAsync(new BlobRequest(blobName));
+        result.ShouldNotBeNull();
+        result!.Data.ToString().ShouldBe("S3 Cycle Test");
+
+        // Public URL
+        var url = await service.GetPublicAccessUrl(new BlobRequest(blobName));
+        url.ShouldNotBeNull();
+
+        // List
+        var items = new List<BlobDetails.BlobResult>();
+        await foreach (var item in service.ListItemsAsync(new BlobRequest(""))) items.Add(item);
+        items.ShouldNotBeEmpty();
+
+        // Delete
+        (await service.DeleteAsync(new BlobRequest(blobName))).ShouldBeTrue();
+        (await service.CheckExistsAsync(new BlobRequest(blobName))).ShouldBeFalse();
+    }
+
+    #endregion
+
+    #region AzureStorageBlobService Tests
+
+    [Fact]
+    public async Task Azure_SaveAsync_DisallowedExtension_ShouldThrowFileLoadException()
+    {
+        using var fixture = new AzureStorageBlobServiceFixture();
+        var options = new AzureStorageOptions 
+        { 
+            ConnectionString = "UseDevelopmentStorage=true", 
+            ContainerName = "test", 
+            IncludedExtensions = [".txt"] 
+        };
+        var service = new AzureStorageBlobService(Options.Create(options));
+        var blobData = new BlobDetails.BlobData("test.pdf", BinaryData.FromString("test"));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File extension is invalid.");
+    }
+
+    [Fact]
+    public async Task Azure_SaveAsync_OversizedFile_ShouldThrowFileLoadException()
+    {
+        using var fixture = new AzureStorageBlobServiceFixture();
+        var options = new AzureStorageOptions 
+        { 
+            ConnectionString = "UseDevelopmentStorage=true", 
+            ContainerName = "test", 
+            MaxFileSizeInMb = 1 
+        };
+        var service = new AzureStorageBlobService(Options.Create(options));
+        var largeContent = new string('x', 2 * 1024 * 1024);
+        var blobData = new BlobDetails.BlobData("test.txt", BinaryData.FromString(largeContent));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File size is invalid.");
+    }
+
+    [Fact]
+    public async Task Azure_SaveAsync_FileNameTooLong_ShouldThrowFileLoadException()
+    {
+        using var fixture = new AzureStorageBlobServiceFixture();
+        var options = new AzureStorageOptions 
+        { 
+            ConnectionString = "UseDevelopmentStorage=true", 
+            ContainerName = "test", 
+            MaxFileNameLength = 5 
+        };
+        var service = new AzureStorageBlobService(Options.Create(options));
+        var blobData = new BlobDetails.BlobData("verylongfilename.txt", BinaryData.FromString("test"));
+
+        var exception = await Should.ThrowAsync<FileLoadException>(() => service.SaveAsync(blobData));
+        exception.Message.ShouldBe("File name is invalid.");
+    }
+
+    [Fact]
+    public async Task Azure_SaveAsync_DefaultOptions_ShouldSucceed()
+    {
+        using var fixture = new AzureStorageBlobServiceFixture();
+        var options = new AzureStorageOptions 
+        { 
+            ConnectionString = "UseDevelopmentStorage=true", 
+            ContainerName = "test" 
+        };
+        var service = new AzureStorageBlobService(Options.Create(options));
+        var blobData = new BlobDetails.BlobData("test.txt", BinaryData.FromString("test"));
+
+        var result = await service.SaveAsync(blobData);
+        result.ShouldBe("test.txt");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Promote the merged idempotency SanitizeKey collision fix from `dev` to `main`.

**Changes included:**
- Hash SanitizeKey in NpgsqlStore and DistributedCacheStore to prevent key collisions (internal key-derivation fix only — no consumer-facing API change; old-format keys expire naturally)
- Add tests for idempotency SanitizeKey collision fixes
- Move DistributedCacheStore tests to correct project
- Various test improvements and fixes

**Packages affected:** DKNet.AspCore.Idempotency, DKNet.AspCore.Idempotency.NpgsqlStore