### PR TITLE
[DRK-114] Harden DKNet.Svc.Encryption hashing: _disposed visibility + ignoreCase no-op docs

### DIFF
--- a/src/Services/DKNet.Svc.Encryption/HmacHashing.cs
+++ b/src/Services/DKNet.Svc.Encryption/HmacHashing.cs
@@ -41,7 +41,7 @@ public interface IHmacHashing : IDisposable
     /// <param name="secretKey">The secret key to use for hashing.</param>
     /// <param name="expectedSignature">The expected hash signature to compare against.</param>
     /// <param name="signatureIsBase64">If <c>true</c>, the signature is base64-encoded; otherwise, hexadecimal.</param>
-    /// <param name="ignoreCase">If <c>true</c>, ignores case when comparing signatures.</param>
+    /// <param name="ignoreCase">Has no effect on the result: the comparison always uses <see cref="CryptographicOperations.FixedTimeEquals" /> on the decoded signature bytes, so signatures are compared exactly regardless of this flag.</param>
     /// <returns><c>true</c> if the computed hash matches the expected signature; otherwise, <c>false</c>.</returns>
     bool VerifySha256(
         string message,
@@ -57,7 +57,7 @@ public interface IHmacHashing : IDisposable
     /// <param name="secretKey">The secret key to use for hashing.</param>
     /// <param name="expectedSignature">The expected hash signature to compare against.</param>
     /// <param name="signatureIsBase64">If <c>true</c>, the signature is base64-encoded; otherwise, hexadecimal.</param>
-    /// <param name="ignoreCase">If <c>true</c>, ignores case when comparing signatures.</param>
+    /// <param name="ignoreCase">Has no effect on the result: the comparison always uses <see cref="CryptographicOperations.FixedTimeEquals" /> on the decoded signature bytes, so signatures are compared exactly regardless of this flag.</param>
     /// <returns><c>true</c> if the computed hash matches the expected signature; otherwise, <c>false</c>.</returns>
     bool VerifySha512(
         string message,
@@ -78,7 +78,7 @@ public sealed class HmacHashing : IHmacHashing
 
     private readonly Dictionary<(HmacAlgorithm alg, string key), HMAC> _cache = [];
     private readonly Lock _sync = new();
-    private bool _disposed;
+    private volatile bool _disposed;
 
     #endregion
 

--- a/src/Services/DKNet.Svc.Encryption/ShaHashing.cs
+++ b/src/Services/DKNet.Svc.Encryption/ShaHashing.cs
@@ -44,7 +44,7 @@ public interface IShaHashing : IDisposable // now disposable so we can release c
     /// </summary>
     /// <param name="input">The input text to hash and compare.</param>
     /// <param name="expectedHex">The expected hexadecimal hash string.</param>
-    /// <param name="ignoreCase">If <c>true</c> performs a case-insensitive comparison.</param>
+    /// <param name="ignoreCase">Has no effect on the result: hex decoding is case-insensitive, so the comparison result is unaffected by this flag.</param>
     /// <returns><c>true</c> if the computed hash equals <paramref name="expectedHex" />; otherwise <c>false</c>.</returns>
     bool VerifySha256(string input, string expectedHex, bool ignoreCase = true);
 
@@ -53,7 +53,7 @@ public interface IShaHashing : IDisposable // now disposable so we can release c
     /// </summary>
     /// <param name="input">The input text to hash and compare.</param>
     /// <param name="expectedHex">The expected hexadecimal hash string.</param>
-    /// <param name="ignoreCase">If <c>true</c> performs a case-insensitive comparison.</param>
+    /// <param name="ignoreCase">Has no effect on the result: hex decoding is case-insensitive, so the comparison result is unaffected by this flag.</param>
     /// <returns><c>true</c> if the computed hash equals <paramref name="expectedHex" />; otherwise <c>false</c>.</returns>
     bool VerifySha512(string input, string expectedHex, bool ignoreCase = true);
 
@@ -69,7 +69,7 @@ public sealed class ShaHashing : IShaHashing
 
     private readonly Dictionary<HashAlgorithmKind, HashAlgorithm> _algorithms = [];
     private readonly object _sync = new(); // changed to object for locking
-    private bool _disposed;
+    private volatile bool _disposed;
 
     #endregion
 

--- a/src/Services/Svc.Encryption.Tests/HmacHashingDisposeTests.cs
+++ b/src/Services/Svc.Encryption.Tests/HmacHashingDisposeTests.cs
@@ -1,0 +1,45 @@
+using System;
+using DKNet.Svc.Encryption;
+using Shouldly;
+using Xunit;
+
+namespace Svc.Encryption.Tests;
+
+public class HmacHashingDisposeTests
+{
+    #region Methods
+
+    [Fact]
+    public void HmacHashing_AfterDispose_ThrowsObjectDisposedException_OnComputeSha256()
+    {
+        var hmac = new HmacHashing();
+        hmac.Dispose();
+        Should.Throw<ObjectDisposedException>(() => hmac.ComputeSha256("message", "key"));
+    }
+
+    [Fact]
+    public void HmacHashing_AfterDispose_ThrowsObjectDisposedException_OnComputeSha512()
+    {
+        var hmac = new HmacHashing();
+        hmac.Dispose();
+        Should.Throw<ObjectDisposedException>(() => hmac.ComputeSha512("message", "key"));
+    }
+
+    [Fact]
+    public void HmacHashing_AfterDispose_ThrowsObjectDisposedException_OnVerifySha256()
+    {
+        var hmac = new HmacHashing();
+        hmac.Dispose();
+        Should.Throw<ObjectDisposedException>(() => hmac.VerifySha256("message", "key", "sig"));
+    }
+
+    [Fact]
+    public void HmacHashing_AfterDispose_ThrowsObjectDisposedException_OnVerifySha512()
+    {
+        var hmac = new HmacHashing();
+        hmac.Dispose();
+        Should.Throw<ObjectDisposedException>(() => hmac.VerifySha512("message", "key", "sig"));
+    }
+
+    #endregion
+}

--- a/src/Services/Svc.Encryption.Tests/HmacHashingIgnoreCaseTests.cs
+++ b/src/Services/Svc.Encryption.Tests/HmacHashingIgnoreCaseTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using DKNet.Svc.Encryption;
+using Shouldly;
+using Xunit;
+
+namespace Svc.Encryption.Tests;
+
+public class HmacHashingIgnoreCaseTests
+{
+    #region Methods
+
+    [Fact]
+    public void HmacHashing_VerifySha256_IgnoreCaseTrueOrFalse_ReturnsSameResult()
+    {
+        using var hmac = new HmacHashing();
+        var message = "test message";
+        var secretKey = "secret";
+        var sig = hmac.ComputeSha256(message, secretKey, false); // hex signature
+
+        var mixedCaseSig = new string([.. sig.Select((c, i) => i % 2 == 0 ? char.ToUpper(c) : char.ToLower(c))]);
+
+        var rTrue = hmac.VerifySha256(message, secretKey, mixedCaseSig, false, true);
+        var rFalse = hmac.VerifySha256(message, secretKey, mixedCaseSig, false, false);
+
+        rTrue.ShouldBe(rFalse);
+        rTrue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HmacHashing_VerifySha512_IgnoreCaseTrueOrFalse_ReturnsSameResult()
+    {
+        using var hmac = new HmacHashing();
+        var message = "test message";
+        var secretKey = "secret";
+        var sig = hmac.ComputeSha512(message, secretKey, false); // hex signature
+
+        var mixedCaseSig = new string([.. sig.Select((c, i) => i % 2 == 0 ? char.ToUpper(c) : char.ToLower(c))]);
+
+        var rTrue = hmac.VerifySha512(message, secretKey, mixedCaseSig, false, true);
+        var rFalse = hmac.VerifySha512(message, secretKey, mixedCaseSig, false, false);
+
+        rTrue.ShouldBe(rFalse);
+        rTrue.ShouldBeTrue();
+    }
+
+    #endregion
+}

--- a/src/Services/Svc.Encryption.Tests/ShaHashingDisposeTests.cs
+++ b/src/Services/Svc.Encryption.Tests/ShaHashingDisposeTests.cs
@@ -1,0 +1,45 @@
+using System;
+using DKNet.Svc.Encryption;
+using Shouldly;
+using Xunit;
+
+namespace Svc.Encryption.Tests;
+
+public class ShaHashingDisposeTests
+{
+    #region Methods
+
+    [Fact]
+    public void ShaHashing_AfterDispose_ThrowsObjectDisposedException_OnComputeSha256()
+    {
+        var sha = new ShaHashing();
+        sha.Dispose();
+        Should.Throw<ObjectDisposedException>(() => sha.ComputeSha256("input"));
+    }
+
+    [Fact]
+    public void ShaHashing_AfterDispose_ThrowsObjectDisposedException_OnComputeSha512()
+    {
+        var sha = new ShaHashing();
+        sha.Dispose();
+        Should.Throw<ObjectDisposedException>(() => sha.ComputeSha512("input"));
+    }
+
+    [Fact]
+    public void ShaHashing_AfterDispose_ThrowsObjectDisposedException_OnVerifySha256()
+    {
+        var sha = new ShaHashing();
+        sha.Dispose();
+        Should.Throw<ObjectDisposedException>(() => sha.VerifySha256("input", "expected"));
+    }
+
+    [Fact]
+    public void ShaHashing_AfterDispose_ThrowsObjectDisposedException_OnVerifySha512()
+    {
+        var sha = new ShaHashing();
+        sha.Dispose();
+        Should.Throw<ObjectDisposedException>(() => sha.VerifySha512("input", "expected"));
+    }
+
+    #endregion
+}

--- a/src/Services/Svc.Encryption.Tests/ShaHashingIgnoreCaseTests.cs
+++ b/src/Services/Svc.Encryption.Tests/ShaHashingIgnoreCaseTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using DKNet.Svc.Encryption;
+using Shouldly;
+using Xunit;
+
+namespace Svc.Encryption.Tests;
+
+public class ShaHashingIgnoreCaseTests
+{
+    #region Methods
+
+    [Fact]
+    public void ShaHashing_VerifySha256_IgnoreCaseTrueOrFalse_ReturnsSameResult()
+    {
+        using var sha = new ShaHashing();
+        var message = "test message";
+        var hex = sha.ComputeSha256(message);
+
+        var mixedCaseHex = new string([.. hex.Select((c, i) => i % 2 == 0 ? char.ToUpper(c) : char.ToLower(c))]);
+
+        var rTrue = sha.VerifySha256(message, mixedCaseHex, true);
+        var rFalse = sha.VerifySha256(message, mixedCaseHex, false);
+
+        rTrue.ShouldBe(rFalse);
+        rTrue.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ShaHashing_VerifySha512_IgnoreCaseTrueOrFalse_ReturnsSameResult()
+    {
+        using var sha = new ShaHashing();
+        var message = "test message";
+        var hex = sha.ComputeSha512(message);
+
+        var mixedCaseHex = new string([.. hex.Select((c, i) => i % 2 == 0 ? char.ToUpper(c) : char.ToLower(c))]);
+
+        var rTrue = sha.VerifySha512(message, mixedCaseHex, true);
+        var rFalse = sha.VerifySha512(message, mixedCaseHex, false);
+
+        rTrue.ShouldBe(rFalse);
+        rTrue.ShouldBeTrue();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Low-priority hardening from the SEC-006 constant-time-compare review follow-ups (DRK-114):

- `HmacHashing._disposed` and `ShaHashing._disposed` are now `volatile` — `Dispose()` writes are deterministically visible to `Compute`/`Verify` reads on another thread, without adding locking to the hot paths.
- Corrected the `ignoreCase` `<param>` XML docs on `IHmacHashing.VerifySha256/VerifySha512` and `IShaHashing.VerifySha256/VerifySha512` to state the flag has no effect on the result (comparisons use `CryptographicOperations.FixedTimeEquals` on decoded bytes, which are always compared exactly).
- No behavioural change; no public API surface change.

## Tests

- `HmacHashingDisposeTests` / `ShaHashingDisposeTests` — dispose-then-verify throws `ObjectDisposedException` deterministically.
- `HmacHashingIgnoreCaseTests` / `ShaHashingIgnoreCaseTests` — `ignoreCase: true`/`false` return identical results for a mixed-case expected signature/hex string.
- Suite: 99 passed, 0 failed. Coverage on touched classes: `HmacHashing` 98.1%, `ShaHashing` 98.1%. `dotnet pack` clean.

## Scope

`src/Services/DKNet.Svc.Encryption/{HmacHashing.cs,ShaHashing.cs}` + 4 new test files under `src/Services/Svc.Encryption.Tests/`.
