### PR TITLE
[DRK-175] Atomic idempotency key reservation (PostgreSQL store)

### DIFF
--- a/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Integration/IdempotencyIntegrationTests.cs
+++ b/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Integration/IdempotencyIntegrationTests.cs
@@ -54,9 +54,8 @@ public sealed class IdempotencyIntegrationTests(ApiFixture fixture) : IAsyncLife
         var idempotencyKey = Guid.NewGuid().ToString();
         var request = new CreateItemRequest { Name = "Concurrent Item" };
 
-        // Act - Send 5 concurrent requests with the same idempotency key
-        // multiple requests may process simultaneously when they all arrive before any is cached.
-        // This is a known limitation of stateless filters without distributed locking.
+        // Act - Send 5 concurrent requests with the same idempotency key.
+        // The store's atomic reservation ensures at most one of them ever reaches the handler.
         var tasks = Enumerable.Range(0, 5).Select(_ =>
         {
             var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/items")
@@ -69,19 +68,20 @@ public sealed class IdempotencyIntegrationTests(ApiFixture fixture) : IAsyncLife
 
         var responses = await Task.WhenAll(tasks);
 
-        // Assert - With concurrent requests, some or all may succeed (201 or 409 Conflict)
-        // The first request wins, subsequent ones get 409 Conflict (if ConflictHandling = ConflictResponse)
-        // or the cached response (if ConflictHandling = CachedResult)
-        var successCount = responses.Count(r => r.StatusCode == HttpStatusCode.Created);
-        var conflictCount = responses.Count(r => r.StatusCode == HttpStatusCode.Conflict);
+        // Assert - the fixture uses ConflictHandling = CachedResult, so a duplicate arriving after the
+        // winner completes legitimately gets 201 with the replayed body, not 409; we don't assert an
+        // exact 201/409 split. Instead: the handler generates a fresh Guid per call, so every 201
+        // response carrying the SAME Id proves the handler ran exactly once.
+        var createdIds = new List<Guid>();
+        foreach (var response in responses)
+        {
+            if (response.StatusCode != HttpStatusCode.Created) continue;
+            var item = await response.Content.ReadFromJsonAsync<CreateItemResponse>();
+            createdIds.Add(item!.Id);
+        }
 
-        // At least one should succeed (201)
-        successCount.ShouldBeGreaterThanOrEqualTo(1);
-
-        // The rest should be conflicts or cached responses
-        var otherCount = responses.Count(r => r.StatusCode != HttpStatusCode.Created &&
-                                              r.StatusCode != HttpStatusCode.Conflict);
-        (successCount + conflictCount + otherCount).ShouldBe(5);
+        createdIds.ShouldNotBeEmpty("At least one request should have succeeded");
+        createdIds.Distinct().Count().ShouldBe(1, "The handler must have executed exactly once");
 
         // Verify only ONE entry in database (unique constraint ensures this)
         await using var dbContext = fixture.GetDbContext();
@@ -323,6 +323,51 @@ public sealed class IdempotencyIntegrationTests(ApiFixture fixture) : IAsyncLife
         response.StatusCode.ShouldBe(HttpStatusCode.Created);
         var item = await response.Content.ReadFromJsonAsync<CreateItemResponse>();
         item!.Name.ShouldBe("Expired Key Item");
+        item.Id.ShouldNotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task CreateItem_WithExpiredInFlightReservation_ProcessesAsNewRequest()
+    {
+        // Arrange - seed an already-expired StatusCode=102 reservation placeholder directly, simulating
+        // a prior request whose handler never completed (crashed, timed out) within the reservation window.
+        var idempotencyKey = Guid.NewGuid().ToString();
+        var request = new CreateItemRequest { Name = "Expired Reservation Item" };
+
+        await using (var seedDbContext = fixture.GetDbContext())
+        {
+            var expiredReservation = new IdempotencyKeyEntity(
+                new IdempotentKeyInfo
+                {
+                    IdempotentKey = idempotencyKey,
+                    Endpoint = "/api/items",
+                    Method = "POST"
+                },
+                new CachedResponse
+                {
+                    StatusCode = 102,
+                    Body = null,
+                    ContentType = "application/json",
+                    CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                    ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+                });
+
+            seedDbContext.IdempotencyKeys.Add(expiredReservation);
+            await seedDbContext.SaveChangesAsync();
+        }
+
+        // Act - a request with the same key must not be permanently blocked by the stale reservation
+        var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/items")
+        {
+            Headers = { { "X-Idempotency-Key", idempotencyKey } },
+            Content = JsonContent.Create(request)
+        };
+        var response = await fixture.HttpClient!.SendAsync(httpRequest);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.Created);
+        var item = await response.Content.ReadFromJsonAsync<CreateItemResponse>();
+        item!.Name.ShouldBe("Expired Reservation Item");
         item.Id.ShouldNotBe(Guid.Empty);
     }
 

--- a/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Integration/IdempotencyIntegrationTests.cs
+++ b/src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Integration/IdempotencyIntegrationTests.cs
@@ -371,6 +371,64 @@ public sealed class IdempotencyIntegrationTests(ApiFixture fixture) : IAsyncLife
         item.Id.ShouldNotBe(Guid.Empty);
     }
 
+    [Fact]
+    public async Task CreateItem_ConcurrentRequestsAgainstExpiredReservation_OnlyOneProcessed()
+    {
+        // Arrange - seed an already-expired StatusCode=102 reservation so every concurrent request's
+        // initial unexpired-row query misses it, and every request's own reservation INSERT collides
+        // with this same stale row (unique index doesn't care that it's expired).
+        var idempotencyKey = Guid.NewGuid().ToString();
+        var request = new CreateItemRequest { Name = "Expired Reservation Race Item" };
+
+        await using (var seedDbContext = fixture.GetDbContext())
+        {
+            var expiredReservation = new IdempotencyKeyEntity(
+                new IdempotentKeyInfo
+                {
+                    IdempotentKey = idempotencyKey,
+                    Endpoint = "/api/items",
+                    Method = "POST"
+                },
+                new CachedResponse
+                {
+                    StatusCode = 102,
+                    Body = null,
+                    ContentType = "application/json",
+                    CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-2),
+                    ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1)
+                });
+
+            seedDbContext.IdempotencyKeys.Add(expiredReservation);
+            await seedDbContext.SaveChangesAsync();
+        }
+
+        // Act - fire 5 concurrent requests against the same key, all racing the stale expired row
+        var tasks = Enumerable.Range(0, 5).Select(_ =>
+        {
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, "/api/items")
+            {
+                Headers = { { "X-Idempotency-Key", idempotencyKey } },
+                Content = JsonContent.Create(request)
+            };
+            return fixture.HttpClient!.SendAsync(httpRequest);
+        }).ToArray();
+
+        var responses = await Task.WhenAll(tasks);
+
+        // Assert - only one distinct handler execution must be observable, same as the fresh-key case
+        var createdIds = new List<Guid>();
+        foreach (var response in responses)
+        {
+            if (response.StatusCode != HttpStatusCode.Created) continue;
+            var item = await response.Content.ReadFromJsonAsync<CreateItemResponse>();
+            createdIds.Add(item!.Id);
+        }
+
+        createdIds.ShouldNotBeEmpty("At least one request should have succeeded");
+        createdIds.Distinct().Count().ShouldBe(1,
+            "The handler must have executed exactly once, even when racing an already-expired reservation row");
+    }
+
     public Task DisposeAsync() => Task.CompletedTask;
 
     public Task InitializeAsync() => Task.CompletedTask;

--- a/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Data/IdempotencyKeyEntity.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Data/IdempotencyKeyEntity.cs
@@ -102,6 +102,21 @@ internal sealed class IdempotencyKeyEntity
     #region Methods
 
     /// <summary>
+    ///     Completes an in-flight reservation placeholder in place, overwriting it with the actual
+    ///     processed response. Used when this row was inserted as a <c>StatusCode == 102</c> reservation
+    ///     and the protected handler has now finished, so the row transitions from placeholder to
+    ///     completed cache entry without a second insert.
+    /// </summary>
+    /// <param name="response">The cached response to store.</param>
+    internal void Complete(CachedResponse response)
+    {
+        StatusCode = response.StatusCode;
+        Body = response.Body;
+        ContentType = response.ContentType;
+        ExpiresAt = response.ExpiresAt;
+    }
+
+    /// <summary>
     ///     Sanitizes an idempotency key for use as a database key by hashing it.
     ///     Hashing (rather than stripping characters) guarantees structurally distinct
     ///     composite keys never collapse onto the same database key.

--- a/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Store/IdempotencyPostgresStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Store/IdempotencyPostgresStore.cs
@@ -153,10 +153,40 @@ internal sealed class IdempotencyPostgresStore(
             }
 
             // The row blocking our insert is itself expired (a stale reservation or completed entry
-            // nothing ever purged). Treat this request as not-processed and let it run the handler;
-            // MarkKeyAsProcessedAsync reclaims that row in place once processing completes.
-            logger.LogDebug("Blocking idempotency key row has expired, proceeding as new: {Key}", sanitizedKey);
-            return (false, null);
+            // nothing ever purged). Reclaiming it with a plain read-then-write would reopen the same
+            // race this method exists to close, so reclaim it atomically: a conditional UPDATE that
+            // only matches while the row is still expired. Its affected-row count gives the same
+            // single-winner guarantee the unique index gives the fresh-insert path - only the caller
+            // whose UPDATE actually flips the row wins; every other concurrent racer's UPDATE affects
+            // zero rows once the winner has moved ExpiresAt into the future.
+            var now = DateTime.UtcNow;
+            var reclaimed = await dbContext.IdempotencyKeys
+                .Where(k => k.CompositeKey == sanitizedKey && k.ExpiresAt != null && k.ExpiresAt <= now)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(k => k.StatusCode, 102)
+                    .SetProperty(k => k.Body, (string?)null)
+                    .SetProperty(k => k.ContentType, "application/json")
+                    .SetProperty(k => k.CreatedAt, now)
+                    .SetProperty(k => k.ExpiresAt, now + options.Value.InFlightReservationTimeout))
+                .ConfigureAwait(false);
+
+            if (reclaimed == 1)
+            {
+                logger.LogDebug("Reclaimed expired idempotency key row, proceeding as new: {Key}", sanitizedKey);
+                return (false, null);
+            }
+
+            // Another caller reclaimed (or completed) the row between our insert collision and this
+            // reclaim attempt - re-read its current state and branch exactly like the unexpired path.
+            var current = await dbContext.IdempotencyKeys
+                .AsNoTracking()
+                .FirstOrDefaultAsync(k => k.CompositeKey == sanitizedKey)
+                .ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Idempotency key already reserved or processed by a concurrent request: {Key}",
+                sanitizedKey);
+            return (true, current is null || current.StatusCode == 102 ? null : ToCachedResponse(current));
         }
     }
 

--- a/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Store/IdempotencyPostgresStore.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Store/IdempotencyPostgresStore.cs
@@ -8,6 +8,7 @@ using DKNet.AspCore.Idempotency.Store;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Npgsql;
 
 namespace DKNet.AspCore.Idempotency.NpgsqlStore.Store;
@@ -18,7 +19,8 @@ namespace DKNet.AspCore.Idempotency.NpgsqlStore.Store;
 /// </summary>
 internal sealed class IdempotencyPostgresStore(
     IServiceProvider serviceProvider,
-    ILogger<IdempotencyPostgresStore> logger) : IIdempotencyKeyStore, IAsyncDisposable
+    ILogger<IdempotencyPostgresStore> logger,
+    IOptions<IdempotencyOptions> options) : IIdempotencyKeyStore, IAsyncDisposable
 {
     #region Fields
 
@@ -84,13 +86,13 @@ internal sealed class IdempotencyPostgresStore(
         if (existing == null)
         {
             logger.LogDebug("Idempotency key not found or expired: {Key}", sanitizedKey);
-            return (false, null);
+            return await ReserveKeyAsync(dbContext, keyInfo, sanitizedKey).ConfigureAwait(false);
         }
 
         if (existing.IsExpired)
         {
             logger.LogDebug("Idempotency key has expired: {Key}", sanitizedKey);
-            return (false, null);
+            return await ReserveKeyAsync(dbContext, keyInfo, sanitizedKey).ConfigureAwait(false);
         }
 
         logger.LogInformation(
@@ -98,17 +100,75 @@ internal sealed class IdempotencyPostgresStore(
             existing.StatusCode,
             sanitizedKey);
 
-        var cachedResponse = new CachedResponse
-        {
-            StatusCode = existing.StatusCode,
-            Body = existing.Body,
-            ContentType = existing.ContentType ?? "application/json",
-            CreatedAt = existing.CreatedAt,
-            ExpiresAt = existing.ExpiresAt
-        };
-
-        return (true, cachedResponse);
+        return (true, ToCachedResponse(existing));
     }
+
+    /// <summary>
+    ///     Attempts to atomically reserve <paramref name="sanitizedKey" /> by inserting a
+    ///     <c>StatusCode == 102</c> placeholder row, relying on the <c>UX_CompositeKey</c> unique index to
+    ///     serialize concurrent callers — only the caller whose insert succeeds proceeds to run the
+    ///     protected handler.
+    /// </summary>
+    /// <param name="dbContext">The open database context to reserve the key on.</param>
+    /// <param name="keyInfo">The idempotency key information for the reservation row.</param>
+    /// <param name="sanitizedKey">The pre-computed, sanitized composite key.</param>
+    /// <returns>
+    ///     <c>(false, null)</c> if this call reserved the key and the caller should proceed with
+    ///     processing; otherwise <c>(true, response)</c> with the completed duplicate's cached response,
+    ///     or <c>(true, null)</c> if another caller currently holds an unexpired in-flight reservation.
+    /// </returns>
+    private async ValueTask<(bool processed, CachedResponse? response)> ReserveKeyAsync(
+        IdempotencyDbContext dbContext, IdempotentKeyInfo keyInfo, string sanitizedKey)
+    {
+        try
+        {
+            var reservation = new IdempotencyKeyEntity(keyInfo, new CachedResponse
+            {
+                StatusCode = 102,
+                Body = null,
+                ContentType = "application/json",
+                CreatedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = DateTimeOffset.UtcNow + options.Value.InFlightReservationTimeout
+            });
+
+            dbContext.IdempotencyKeys.Add(reservation);
+            await dbContext.SaveChangesAsync().ConfigureAwait(false);
+
+            return (false, null);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // A concurrent request already holds this composite key - find out what state it's in.
+            var blocking = await dbContext.IdempotencyKeys
+                .AsNoTracking()
+                .FirstOrDefaultAsync(k => k.CompositeKey == sanitizedKey)
+                .ConfigureAwait(false);
+
+            if (blocking is { IsExpired: false })
+            {
+                logger.LogInformation(
+                    "Idempotency key already reserved or processed by a concurrent request: {Key}",
+                    sanitizedKey);
+                return (true, blocking.StatusCode == 102 ? null : ToCachedResponse(blocking));
+            }
+
+            // The row blocking our insert is itself expired (a stale reservation or completed entry
+            // nothing ever purged). Treat this request as not-processed and let it run the handler;
+            // MarkKeyAsProcessedAsync reclaims that row in place once processing completes.
+            logger.LogDebug("Blocking idempotency key row has expired, proceeding as new: {Key}", sanitizedKey);
+            return (false, null);
+        }
+    }
+
+    private static CachedResponse ToCachedResponse(IdempotencyKeyEntity entity) =>
+        new()
+        {
+            StatusCode = entity.StatusCode,
+            Body = entity.Body,
+            ContentType = entity.ContentType ?? "application/json",
+            CreatedAt = entity.CreatedAt,
+            ExpiresAt = entity.ExpiresAt
+        };
 
     /// <inheritdoc />
     public async ValueTask MarkKeyAsProcessedAsync(IdempotentKeyInfo keyInfo, CachedResponse cachedResponse)
@@ -125,11 +185,19 @@ internal sealed class IdempotencyPostgresStore(
             var factory =
                 _scope.ServiceProvider.GetRequiredService<IDbContextFactory<IdempotencyDbContext>>();
             await using var dbContext = await factory.CreateDbContextAsync();
-
-            var entity = new IdempotencyKeyEntity(keyInfo, cachedResponse);
             await EnsureDatabaseCreatedAsync(dbContext);
 
-            dbContext.IdempotencyKeys.Add(entity);
+            var reservation = await dbContext.IdempotencyKeys
+                .FirstOrDefaultAsync(k => k.CompositeKey == sanitizedKey)
+                .ConfigureAwait(false);
+
+            if (reservation != null)
+                reservation.Complete(cachedResponse);
+            else
+                // Defensive fallback only - should not happen now that IsKeyProcessedAsync always
+                // reserves the row before the handler runs.
+                dbContext.IdempotencyKeys.Add(new IdempotencyKeyEntity(keyInfo, cachedResponse));
+
             await dbContext.SaveChangesAsync().ConfigureAwait(false);
 
             logger.LogInformation(
@@ -139,7 +207,8 @@ internal sealed class IdempotencyPostgresStore(
         }
         catch (DbUpdateException ex) when (IsUniqueViolation(ex))
         {
-            // Handle race condition: Another concurrent request already inserted this key
+            // Handle race condition: Another concurrent request already inserted this key.
+            // Unreachable in the common path now, kept as a defensive guard around the fallback Add() above.
             logger.LogInformation(
                 "Idempotency key already processed by concurrent request: {Key}. Continuing without duplicate insert.",
                 sanitizedKey);

--- a/src/AspNet/DKNet.AspCore.Idempotency/IdempotencyOptions.cs
+++ b/src/AspNet/DKNet.AspCore.Idempotency/IdempotencyOptions.cs
@@ -71,6 +71,16 @@ public sealed class IdempotencyOptions
     public string IdempotencyKeyPattern { get; set; } = @"^[a-zA-Z0-9\-_]+$";
 
     /// <summary>
+    ///     Gets or sets how long an in-flight reservation placeholder is honoured before being treated as
+    ///     expired and abandoned. A store that makes its check-and-reserve step atomic inserts such a
+    ///     placeholder while the protected handler is running; once this timeout elapses without the
+    ///     reservation being completed (e.g. the handler crashed), a fresh request for the same key is
+    ///     allowed to proceed instead of being permanently blocked.
+    ///     Default is 30 seconds.
+    /// </summary>
+    public TimeSpan InFlightReservationTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     ///     Gets or sets the JSON serializer options used to serialize response bodies before caching them.
     ///     This is used when the conflict handling strategy is set to return cached results.
     ///     Default uses camel case naming policy for consistency with typical JSON APIs.


### PR DESCRIPTION
## Problem

`IdempotencyPostgresStore` had the same non-atomic check-then-act race DRK-75 fixed in `IdempotencySqlServerStore`: `IsKeyProcessedAsync` was a pure read, and `MarkKeyAsProcessedAsync` only wrote afterward, so two concurrent requests with the same idempotency key could both execute the protected handler.

## Fix

- `IdempotencyPostgresStore.IsKeyProcessedAsync` now atomically inserts a `StatusCode=102` reservation placeholder (leveraging the existing `UX_CompositeKey` unique index) before returning "not processed" — only one concurrent caller per key proceeds to run the handler.
- `IdempotencyKeyEntity` gained an internal `Complete(CachedResponse)` mutator so `MarkKeyAsProcessedAsync` completes the reservation row in place instead of blind-inserting.
- `IdempotencyOptions.InFlightReservationTimeout` (default 30s) bounds how long a reservation is honoured before being treated as expired/abandoned.
- A reservation collision against an *expired* row is itself reclaimed atomically via a conditional `ExecuteUpdateAsync` (only one racer's update affects a row) — an intermediate build had a residual race here (an unconditional "proceed as new" let every racer through), closed during this cycle's QC pass.

## Tests

- Tightened `CreateItem_ConcurrentRequestsWithSameKey_OnlyOneProcessed` to assert every concurrent `Created` response carries the identical item id (proves the handler ran once, not just that the DB has one row).
- New `CreateItem_WithExpiredInFlightReservation_ProcessesAsNewRequest` — an expired reservation doesn't permanently block retries.
- New `CreateItem_ConcurrentRequestsAgainstExpiredReservation_OnlyOneProcessed` — concurrent requests racing an expired reservation still execute the handler exactly once.
- `AspCore.Idempotency.NpgsqlStore.Tests`: 19/19, repeated across 5 full runs for determinism. `AspCore.Idempotency.Tests`: 57/57. Coverage on touched files ≥ 97.7%. Clean `dotnet build` and `dotnet pack`.

## Scope

`src/AspNet/DKNet.AspCore.Idempotency.NpgsqlStore/Store/IdempotencyPostgresStore.cs`, `.../Data/IdempotencyKeyEntity.cs`, `src/AspNet/DKNet.AspCore.Idempotency/IdempotencyOptions.cs`, `src/AspNet/AspCore.Idempotency.NpgsqlStore.Tests/Integration/IdempotencyIntegrationTests.cs` — no other files touched.

Addresses finding `IDEM-CONCURRENCY-001` (DRK-175).
